### PR TITLE
Simplify variable display when dimension=1 and name matches component

### DIFF
--- a/src/OCP/Building/solution.jl
+++ b/src/OCP/Building/solution.jl
@@ -1300,15 +1300,29 @@ function Base.show(io::IO, ::MIME"text/plain", sol::Solution)
 
     # Variable (si définie)
     if variable_dimension(sol) > 0
-        println(
-            io,
-            "\n• Variable: ",
-            variable_name(sol),
-            " = (",
-            join(variable_components(sol), ", "),
-            ") = ",
-            variable(sol),
-        )
+        components = variable_components(sol)
+        var_name = variable_name(sol)
+        
+        # Cas simplifié: dimension 1 et nom identique
+        if variable_dimension(sol) == 1 && var_name == components[1]
+            println(
+                io,
+                "\n• Variable: ",
+                var_name,
+                " = ",
+                variable(sol),
+            )
+        else
+            println(
+                io,
+                "\n• Variable: ",
+                var_name,
+                " = (",
+                join(components, ", "),
+                ") = ",
+                variable(sol),
+            )
+        end
         if dim_variable_constraints_box(sol) > 0
             println(io, "  │  Var dual (lb) : ", variable_constraints_lb_dual(sol))
             println(io, "  └─ Var dual (ub) : ", variable_constraints_ub_dual(sol))

--- a/test/problems/solution_example.jl
+++ b/test/problems/solution_example.jl
@@ -7,7 +7,7 @@ function solution_example(; fun=false)
     CTModels.time!(pre_ocp; t0=0.0, tf=1.0)
 
     # set state
-    CTModels.state!(pre_ocp, 2)
+    CTModels.state!(pre_ocp, 2, "x", ["q", "w"])
 
     # set control
     CTModels.control!(pre_ocp, 1)


### PR DESCRIPTION
- Modified Base.show for Solution to skip '= (component)' when variable dimension is 1 and variable name equals component name
- Example: '• Variable: v = (v) = 1.0' → '• Variable: v = 1.0'
- Multi-component display unchanged