### PR TITLE
docs: improve docstrings with cross-references and reorganize API reference

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   call:
     uses: control-toolbox/CTActions/.github/workflows/spell-check.yml@main
+    with:
+      config-path: '_typos.toml'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# CTFlows.jl — Agent Navigation Guide
+
+Quick-reference for any agent working on this repository.
+
+---
+
+## Project Overview
+
+**CTFlows.jl** is a Julia package in the [control-toolbox](https://github.com/control-toolbox) ecosystem.
+It provides the **flow layer** for optimal control problems: assembling systems, integrating ODEs, and building solutions.
+
+---
+
+## Source Architecture
+
+Submodule layout (all public symbols accessed via qualified paths — no top-level exports):
+
+```
+src/
+├── CTFlows.jl          # Top-level manifest — exports nothing
+├── Common/             # Shared types and tags (AbstractTag, AbstractTrait, …)
+├── Data/               # Vector fields and Hamiltonian data structures
+├── Flows/              # AbstractFlow, Flow, MultiPhaseFlow, building logic
+└── Integrators/        # AbstractODEIntegrator, building logic
+
+ext/
+├── CTFlowsSciML/       # SciML ODE integration extension
+├── CTFlowsForwardDiff.jl
+├── CTFlowsOrdinaryDiffEqTsit5.jl
+├── CTFlowsPlots.jl
+└── CTFlowsStaticArrays.jl
+
+test/suite/             # Tests organised by functionality (not by src layout)
+docs/                   # Documenter.jl site (auto-generated API via CTBase)
+dev/                    # Code philosophy, operational rules, plan template (versioned)
+reports/                # Working notes and architectural reports (ephemeral)
+```
+
+---
+
+## Developer resources
+
+| File | Purpose |
+|---|---|
+| [`dev/philosophy/PHILOSOPHY.md`](dev/philosophy/PHILOSOPHY.md) | Code philosophy — modules, types/traits, exceptions, docstrings, testing, docs |
+| [`dev/RULES.md`](dev/RULES.md) | Operational rules — running tests (MCP), building docs, git, output capture |
+| [`dev/planning.md`](dev/planning.md) | Plan template — phases, steps, human checkpoints |
+| [`reports/dev/action_plan.md`](reports/dev/action_plan.md) | Active refactor roadmap (traits / dispatch / multiphase) |
+
+---
+
+## Devin Workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `architecture.md` | — | Introducing new types, restructuring modules, reviewing SOLID/patterns |
+| `docstrings.md` | — | Writing or reviewing Julia docstrings |
+| `documentation.md` | `glob: docs/**/*` | Documenter.jl layout, `make.jl` template, `api_reference.jl`, `InterLinks` setup |
+| `exceptions.md` | — | Adding error paths, contract stubs, argument validation |
+| `modules.md` | `glob: src/**/*.jl, ext/**/*.jl` | Submodule conventions: qualified imports, manifest pattern, export policy, DAG ordering |
+| `performance.md` | — | Hot paths, inner loops, profiling, benchmarking |
+| `plan.md` | — | Writing an implementation plan before coding |
+| `testing-creation.md` | — | Writing or reviewing test files under `test/suite/` |
+| `testing-execution.md` | `model_decision` | How to run tests (commands, `tee` capture) |
+| `type-stability.md` | — | New structs, parametric types, `@inferred` test design |
+
+Workflows live in `.devin/workflows/`.
+
+---
+
+## Key Conventions
+
+- **No top-level exports** — use `CTFlows.Submodule.symbol` everywhere.
+- **Qualified imports** — `using PackageName: PackageName`, never bare `using`.
+- **Fake types at module top-level** — never inside test functions.
+- **Plans before code** — write a plan and confirm with the user before touching files. Template: [`dev/planning.md`](dev/planning.md).
+- **Docstrings last** — written only after all implementation steps are stable.
+- **Never commit or push without explicit user approval.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CTFlows.jl — Claude project context
+
+## Essential rules
+
+1. **Never commit or push without explicit approval.** Ask first, every time.
+2. **Run tests via the `ct-dev-mcp` MCP** — `get_test_command` → run with `tee` →
+   `generate_report`. Never invent the test command.
+3. **Build docs draft-first** — `draft = true` globally to validate links, then per file
+   with `Draft = false`, then full build. See `dev/RULES.md`.
+4. **Qualify everything** — `Module.symbol` at every call site; `import Pkg: Pkg` not
+   `using Pkg`; no top-level package exports.
+5. **Write a plan before coding** — any task touching more than one file or a public
+   interface needs a plan confirmed by the user first. Template in `dev/planning.md`.
+6. **Docstrings last** — written only after the API is stable.
+7. **Fake types at module top-level** — never inside test functions (world-age issues).
+
+## Where to find more
+
+| Topic | File |
+| --- | --- |
+| Code philosophy (modules, types/traits, exceptions, docstrings, testing, docs) | [`dev/philosophy/`](dev/philosophy/PHILOSOPHY.md) |
+| Operational rules (MCP, doc build, git, output capture) | [`dev/RULES.md`](dev/RULES.md) |
+| Plan template | [`dev/planning.md`](dev/planning.md) |
+| Active refactor roadmap | [`reports/dev/action_plan.md`](reports/dev/action_plan.md) |
+| Architecture reflections | [`reports/dev/`](reports/dev/README.md) |
+
+## Project structure (quick reference)
+
+```text
+src/CTFlows.jl          # top-level manifest — exports nothing
+src/<Module>/<Module>.jl  # submodule manifests
+ext/                    # weak-dependency extensions (SciML, ForwardDiff, …)
+test/suite/             # tests by functionality, not by src layout
+docs/                   # Documenter.jl site
+dev/                    # philosophy, rules, planning template (versioned)
+reports/                # working notes, ephemeral (gitignored in production)
+```
+
+## Key architecture point
+
+`Configs` already has the right model: one abstract type per noun, one trait-parameter
+per orthogonal axis, dispatch via extractor. The active refactor brings `Flows` and
+`Systems` in line with this. See `reports/dev/traits_vs_abstract_types.md`.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,14 @@
+[default]
+locale = "en"
+extend-ignore-re = [
+    "ser",
+]
+
+[files]
+extend-exclude = [
+    "*.json",
+    "*.toml",
+    "*.svg",
+    "save/**",
+    "reports/**",
+]

--- a/dev/RULES.md
+++ b/dev/RULES.md
@@ -1,0 +1,117 @@
+# RULES — tools and procedures for a development agent
+
+**Generic** rules (valid for any Julia package in the control-toolbox ecosystem, with
+no reference to a specific package's code). They describe *how to work*: run tests,
+build docs, handle git, capture output. For *how to design*, see
+[`philosophy/`](philosophy/PHILOSOPHY.md).
+
+---
+
+## 1. Running tests — via the `ct-dev-mcp` MCP server
+
+Do not invent the test command. Use the MCP server that provides it and can parse the
+result.
+
+1. **Get the command**: call the `get_test_command` tool with:
+   - `cwd` = package root (where `Project.toml` lives) — **required**;
+   - `test_args` = scope (empty = everything; `["test/suite/<group>"]`; a single file;
+     a glob `["test/suite/*/*_flow*"]` passed **quoted** — TestRunner expands it, not
+     the shell).
+2. **Run** the returned command verbatim. It already includes
+   `… 2>&1 | tee /tmp/ct-dev-mcp/<pkg>_<scope>_<id>.log`.
+3. **Analyze**: call `generate_report(<log_file>)` on the returned log for a structured
+   Markdown report (summary, first failures, compilation errors).
+
+Rules:
+- **Always `tee` the full log**; never truncate with `tail -N` live — the first error
+  (often a compilation error) is usually *above* and would be lost, forcing a rerun.
+- Inspect the saved log afterwards with `grep`/`rg`/`tail`/`less`, without rerunning.
+- Logs go under `/tmp/…`; **never** commit them.
+- Run the **targeted** suite first (fast iteration), then the **full** suite before
+  considering a phase done (regression check).
+
+---
+
+## 2. Building documentation — "draft first" workflow
+
+`docs/make.jl` exposes a `draft` switch. In **draft mode**, the Julia code in
+`@example`/`@setup` blocks is **not executed**: the build is fast and validates the
+structure, the `@ref`/`@extref` links and the paths. In non-draft mode everything runs
+(slow but actually checks the examples).
+
+```julia
+# docs/make.jl
+draft = true   # does not execute Julia cells
+```
+
+A **single file** can also be forced to non-draft via a meta block, keeping the rest in
+draft — to debug one file quickly:
+
+````markdown
+```@meta
+Draft = false
+```
+````
+
+**Recommended procedure**:
+
+1. **`draft = true`** (global) → build once. Fix all broken **links** (`@ref`/`@extref`)
+   and paths. Fast.
+2. **File by file**: set one file to `Draft = false` (meta block), rebuild, debug its
+   `@example` blocks, fix. Repeat per page. Faster than running everything each time.
+3. **`draft = false`** (global) → final full build, zero execution warnings.
+
+On every build, **`tee`** the output to `/tmp/…` and filter (`grep -E
+"Error|Warning.*failed|MethodError|UndefVar"`).
+
+---
+
+## 3. Git & commits
+
+- **Never commit or push without explicit user approval.** Even after validated work,
+  ask before `git commit`/`git push`.
+- Do not commit on the default branch: branch off the correct base.
+- Interactive flags (`-i`) are not supported in this environment.
+- Prefer the `gh` CLI for GitHub operations (PRs, issues).
+- End commit messages with the required `Co-Authored-By` trailer; end PR bodies with
+  the required generation note.
+- Do not commit transient files (`/tmp/*.log`, doc-build artifacts).
+
+---
+
+## 4. Editing files
+
+- Prefer the **dedicated tools** (read/edit/write) over `cat`/`sed`/`awk`/`echo` in the
+  shell for reading or modifying files.
+- **Read before editing**; do not overwrite a file you have not read.
+- An edit should match the surrounding code (style, naming, comment density).
+
+---
+
+## 5. Capturing long output
+
+- Any verbose command (tests, doc build): `… 2>&1 | tee /tmp/<pkg>_<scope>.log`.
+- Name the log by package + scope to avoid collisions between sessions.
+- Filter the log *afterwards*; do not rerun just to get more context.
+
+---
+
+## 6. Ask vs proceed
+
+- **Ask** before any hard-to-reverse or outward-facing action (commit, push, sending to
+  an external service, deleting/overwriting files you did not create).
+- **Proceed** on choices with an obvious default (style, conventional location),
+  stating it, rather than blocking on a question.
+- Report outcomes faithfully: if tests fail, say so with the output; if a step was
+  skipped, say that.
+
+---
+
+## Quick checklist
+
+- [ ] Tests run via `ct-dev-mcp` (`get_test_command` → run+`tee` → `generate_report`).
+- [ ] Targeted suite green, then full suite green.
+- [ ] Docs built in draft (links OK), then per file, then full.
+- [ ] No git action without explicit approval.
+- [ ] Dedicated file tools used; files read before editing.
+- [ ] Long output captured via `tee` under `/tmp`.

--- a/dev/philosophy/PHILOSOPHY.md
+++ b/dev/philosophy/PHILOSOPHY.md
@@ -1,0 +1,62 @@
+# Code philosophy
+
+Design philosophy for the control-toolbox ecosystem, written **abstractly**: the
+principles apply to all packages, but the examples and templates stay **generic**
+(no package-specific symbols). For *tools and procedures* (tests, docs, git), see
+[`../RULES.md`](../RULES.md).
+
+## The tenets on one page
+
+1. **One module per responsibility.** Each submodule has a single role, its own
+   directory, its own manifest. The package manifest exports **nothing**.
+   → [`modules.md`](modules.md)
+
+2. **Everything is qualified.** Import modules, not their symbols; call
+   `Module.symbol` everywhere. Explicit origin, safe refactors, no shadowing.
+   → [`modules.md`](modules.md)
+
+3. **One abstract type per *noun*, one trait-parameter per *adjective*.** Conceptual
+   variants ("is it an X or a Y") are types; orthogonal axes (autonomous?, in-place?, …)
+   are traits in a type parameter. Dispatch by extracting the trait.
+   → [`types-traits-interfaces.md`](types-traits-interfaces.md)
+
+4. **Program against abstractions.** Methods live on abstract types as much as
+   possible; contracts are `NotImplemented` stubs; subtypes honor the contract (LSP).
+   → [`types-traits-interfaces.md`](types-traits-interfaces.md)
+
+5. **SOLID, DRY, KISS, YAGNI.** Single responsibility, open/closed via dispatch, no
+   duplication, the simplest thing that works, nothing speculative.
+   → [`types-traits-interfaces.md`](types-traits-interfaces.md)
+
+6. **Structured errors.** Seven typed exceptions; sharp rule: single-argument value →
+   `IncorrectArgument`; relation/state/composition → `PreconditionError`; unimplemented
+   contract → `NotImplemented`; optional dependency → `ExtensionError`.
+   → [`exceptions.md`](exceptions.md)
+
+7. **Type stability by default.** Parametric types, no `Any` in hot paths, function
+   barriers, verified with `@inferred`.
+   → [`types-traits-interfaces.md`](types-traits-interfaces.md#type-stability)
+
+8. **Everything is documented.** A docstring on every symbol, fixed templates,
+   cross-references `@ref`/`@extref`, safe and reproducible examples.
+   → [`docstrings.md`](docstrings.md)
+
+9. **Tests: module + callable function + everything qualified.** Each test file is a
+   module with an entry function redefined in the outer scope; fakes at module
+   top-level; categories unit / integration / contract / error.
+   → [`testing.md`](testing.md)
+
+10. **Auto-generated API docs, public *and* private; guides separate.** Users reach
+    internals via qualified paths, so both are documented.
+    → [`documentation.md`](documentation.md)
+
+## Index
+
+| File | Content |
+|---|---|
+| [`modules.md`](modules.md) | Submodule organization, imports/qualification, DAG, exports |
+| [`types-traits-interfaces.md`](types-traits-interfaces.md) | Types vs traits, interfaces/contracts, SOLID/DRY/YAGNI, type stability |
+| [`exceptions.md`](exceptions.md) | The 7 exceptions and the choice rule |
+| [`docstrings.md`](docstrings.md) | Docstring templates, cross-references, example safety |
+| [`testing.md`](testing.md) | Categories, fakes/stubs, **module + callable function template** |
+| [`documentation.md`](documentation.md) | API generation, guides, draft workflow |

--- a/dev/philosophy/docstrings.md
+++ b/dev/philosophy/docstrings.md
@@ -1,0 +1,136 @@
+# Docstrings
+
+Every exported symbol *and* every internal component carries a docstring. Generic
+templates below; use `DocStringExtensions` macros for signatures.
+
+## Principles
+
+1. **Completeness** — document every function, struct, abstract type, macro, module.
+2. **Accuracy** — describe actual behavior, never aspirational.
+3. **Clarity** — for readers fluent in Julia but new to the domain.
+4. **Consistency** — follow the templates.
+
+Placement: **immediately above** the declaration, no blank line in between.
+
+## Required structure
+
+1. Signature via `$(TYPEDSIGNATURES)` (functions) or `$(TYPEDEF)` (types).
+2. One-sentence summary.
+3. Optional detail: behavior, constraints, invariants, edge cases.
+4. Sections as applicable: `# Arguments`, `# Fields`, `# Returns`, `# Throws`,
+   `# Example(s)`, `# Notes`, `# References`, and a `See also:` line.
+
+## Templates (generic)
+
+### Function
+
+```julia
+"""
+$(TYPEDSIGNATURES)
+
+One sentence describing what the function does.
+
+# Arguments
+- `a::TypeA`: description.
+- `b::TypeB`: description.
+
+# Returns
+- `RetType`: description.
+
+# Throws
+- `ExceptionType`: when and why.
+
+# Example
+\`\`\`julia-repl
+julia> using MyPackage.SubA
+
+julia> do_thing(a, b)
+expected_output
+\`\`\`
+
+See also: [`MyPackage.SubA.related`](@ref), [`MyPackage.SubB.Other`](@ref)
+"""
+function do_thing(a::TypeA, b::TypeB)::RetType
+    # ...
+end
+```
+
+### Struct
+
+```julia
+"""
+$(TYPEDEF)
+
+One sentence describing what this type represents.
+
+# Fields
+- `field1::Type1`: description and constraints.
+- `field2::Type2`: description and constraints.
+
+See also: [`MyPackage.SubA.related_type`](@ref)
+"""
+struct Thing{T}
+    field1::Type1
+    field2::T
+end
+```
+
+### Abstract type
+
+```julia
+"""
+$(TYPEDEF)
+
+One sentence describing the abstraction.
+
+# Interface Requirements
+
+Subtypes must implement:
+- `required_method(::SubType)`: description.
+
+See also: [`MyPackage.SubA.ConcreteA`](@ref), [`MyPackage.SubA.ConcreteB`](@ref)
+"""
+abstract type AbstractThing end
+```
+
+## Cross-references
+
+- **Internal** (`@ref`): full module path including the root package.
+  `[`MyPackage.SubA.do_thing`](@ref)` — not `[`do_thing`](@ref)`.
+- **External** (`@extref`): symbols from a dependency with its own docs, full path.
+  `[`OtherPkg.Sub.Sym`](@extref)`. Each must be backed by an `InterLinks` entry in
+  `make.jl`.
+
+Use `@ref` for symbols documented in the current package, `@extref` for dependencies.
+
+## Module-prefix convention in examples
+
+- Exported symbol after `using MyPackage.SubA`: call it bare (`do_thing(...)`).
+- Internal symbol: prefix with the submodule (`SubA.helper(...)`).
+- Public path shown in docs is always `RootPackage.SubModule.symbol`.
+
+## Example safety
+
+Examples must be safe and reproducible.
+
+- ✅ pure deterministic computations, constructors with simple inputs, queries on
+  created objects; start with `using RootPackage.SubModule`.
+- ❌ file/network/DB/git operations, randomness without a seed, timing-dependent or
+  long-running (>1s) code, reliance on external/global state.
+- If no safe runnable example exists: use a plain ```julia block (not ```julia-repl)
+  showing a conceptual usage pattern without claiming output.
+
+## Macros
+
+- `$(TYPEDEF)` — type signature for structs/abstract types.
+- `$(TYPEDSIGNATURES)` — function signature with types.
+
+Use these instead of writing signatures by hand.
+
+## Checklist
+
+- [ ] Directly above the declaration; uses `$(TYPEDEF)`/`$(TYPEDSIGNATURES)`.
+- [ ] One-sentence summary; all args/fields documented; returns and throws when relevant.
+- [ ] Example is safe, runnable, and typical.
+- [ ] `@ref` for internal, `@extref` for external; full module paths.
+- [ ] No invented behavior; consistent terminology.

--- a/dev/philosophy/documentation.md
+++ b/dev/philosophy/documentation.md
@@ -1,0 +1,93 @@
+# Documentation site
+
+How docstrings become a published site via Documenter.jl and
+`CTBase.automatic_reference_documentation()`. Generic examples. Complements
+[`docstrings.md`](docstrings.md) (what to write *inside* docstrings).
+
+## Principles
+
+1. **Auto-generated API reference** — never hand-write API pages; generate one per
+   submodule (and one per loaded extension).
+2. **Public + private documented** — both `public=true` and `private=true`: users reach
+   internals via qualified paths, so internals are part of the documented surface.
+3. **Guides separate from API** — narrative guides are hand-written under
+   `docs/src/<topic>/`; the API reference is generated and cleaned up after the build.
+4. **Index is the entry point** — `docs/src/index.md`: scope, module table, guide links,
+   a short Quick Start.
+5. **Cross-refs resolve at build time** — every `@extref` is backed by an `InterLinks`
+   entry in `make.jl`.
+
+## Layout
+
+```text
+docs/
+├── make.jl              # entry point; uses with_api_reference()
+├── api_reference.jl     # generate_api_reference() + with_api_reference() + cleanup
+├── inventories/         # InterLinks fallback inventories (one per dependency)
+└── src/
+    ├── index.md         # landing page
+    ├── <topic>/         # hand-written guides
+    └── api/             # auto-generated (removed after build)
+```
+
+## API generation (per submodule)
+
+```julia
+CTBase.automatic_reference_documentation(;
+    subdirectory                 = "api",
+    primary_modules              = [MyPackage.SubA => src("SubA/SubA.jl", "SubA/x.jl")],
+    external_modules_to_document = [MyPackage],   # include re-exported symbols
+    exclude                      = Symbol[:include, :eval],
+    public                       = true,
+    private                      = true,
+    title                        = "SubA",
+    filename                     = "api_suba",
+)
+```
+
+Keep the per-submodule file lists in sync with `src/` — a missing file silently drops
+docstrings and breaks `@ref` links. Extensions are detected with `Base.get_extension`
+and documented conditionally.
+
+## Cross-reference infrastructure
+
+```julia
+using DocumenterInterLinks
+links = InterLinks(
+    "OtherPkg" => ("https://.../OtherPkg.jl/stable/",
+                   "https://.../OtherPkg.jl/stable/objects.inv",
+                   joinpath(@__DIR__, "inventories", "OtherPkg.toml")),
+)
+makedocs(; plugins=[links], ...)   # makes [`OtherPkg.Sub.Sym`](@extref) resolve
+```
+
+## The draft switch (development workflow)
+
+`make.jl` exposes `draft`. In draft mode, `@example`/`@setup` Julia cells are **not
+executed** — fast structural/link validation. Per-file override:
+
+````markdown
+```@meta
+Draft = false
+```
+````
+
+Workflow: build with `draft = true` first (fix all links fast), then flip one file at a
+time to `Draft = false` to debug its examples, then `draft = false` globally for the
+final full build. (Operational details in [`../RULES.md`](../RULES.md).)
+
+## Index page
+
+Mandatory pieces of `docs/src/index.md`: a `@meta CurrentModule` block, a one-paragraph
+scope statement, info/note/warning admonitions (notably the qualified-access policy), a
+module table, guide links via `[@ref]`, and a short Quick Start with qualified calls.
+
+## Checklist
+
+- [ ] `make.jl` uses `with_api_reference()`; `api_reference.jl` has generate/with/cleanup.
+- [ ] One `automatic_reference_documentation` per submodule, `public=true` + `private=true`.
+- [ ] Extensions detected via `Base.get_extension` and documented when present.
+- [ ] `InterLinks` set up and passed via `plugins=[links]` if `@extref` is used.
+- [ ] Guides under `docs/src/<topic>/`; no hand-written API pages.
+- [ ] `index.md` has meta, scope, admonitions, module table, guide links, Quick Start.
+- [ ] Built clean: draft (links) → per file → full.

--- a/dev/philosophy/exceptions.md
+++ b/dev/philosophy/exceptions.md
@@ -1,0 +1,104 @@
+# Exceptions
+
+Structured, informative errors. The ecosystem provides seven exception types under
+`CTException`, imported via `import CTBase.Exceptions`.
+
+## Principles
+
+1. **Clear message** — immediately understandable.
+2. **Actionable suggestion** — how to fix it.
+3. **Rich context** — what was expected, what was received, where.
+4. **Typed** — pick the right exception so callers can catch precisely.
+
+## The seven types
+
+| Type | Key fields | Use when |
+|---|---|---|
+| `IncorrectArgument` | `msg, got, expected, suggestion, context` | a single argument's value is out of domain |
+| `PreconditionError` | `msg, reason, suggestion, context` | arguments valid individually, but the call's relation/state/timing is forbidden |
+| `NotImplemented` | `msg, required_method, suggestion, context` | interface stub a subtype must implement |
+| `ParsingError` | `msg, location, suggestion` | DSL / syntax / structure error |
+| `AmbiguousDescription` | `description, candidates, suggestion, context` | a symbol-tuple description matches no catalogue entry |
+| `ExtensionError` | `weakdeps, feature, context` | an optional (weak) dependency is not loaded |
+| `SolverFailure` | `msg, retcode, suggestion, context` | a numerical solver/integrator failed |
+
+## The choice rule
+
+> **`IncorrectArgument`** = "*this value* is wrong" (domain of **one** argument).
+> **`PreconditionError`** = "*this combination / state / timing* is wrong" (a
+> **relational** or contextual contract, each argument valid on its own).
+
+Operational heuristic: if the message must mention **two things** ("x relative to y",
+"this after that"), it is almost always `PreconditionError`. If it mentions **one**
+value ("n must be > 0"), it is `IncorrectArgument`.
+
+Note the fields: `IncorrectArgument` has `got`/`expected` (**no** `reason`);
+`PreconditionError` has `reason`. Using the wrong field is a tell that the type is wrong.
+
+## Examples (generic)
+
+```julia
+import CTBase.Exceptions
+
+# Single-argument domain violation
+throw(Exceptions.IncorrectArgument(
+    "dimension must be positive";
+    got = "n = -1", expected = "n > 0",
+    suggestion = "pass a positive integer for n",
+    context = "make_thing",
+))
+
+# Relational / state violation
+throw(Exceptions.PreconditionError(
+    "cannot combine A with B";
+    reason = "A carries x, B carries (x, p): the handoff is undefined",
+    suggestion = "combine objects of the same kind",
+    context = "composition",
+))
+
+# Interface stub on an abstract type
+function run(s::AbstractStrategy, x)
+    throw(Exceptions.NotImplemented(
+        "run not implemented for $(typeof(s))";
+        required_method = "run(::$(typeof(s)), x)",
+        suggestion = "define run for your strategy type",
+        context = "AbstractStrategy contract",
+    ))
+end
+
+# Optional dependency missing (extension stub)
+throw(Exceptions.ExtensionError(:SomeBackend; feature = "AD", context = "build"))
+
+# Numerical failure
+throw(Exceptions.SolverFailure(
+    "integration failed"; retcode = ":Unstable",
+    suggestion = "reduce the step or check initial conditions",
+))
+```
+
+## Testing exceptions
+
+```julia
+Test.@test_throws Exceptions.IncorrectArgument bad_call()
+
+err = try bad_call() catch e; e end
+Test.@test err isa Exceptions.IncorrectArgument
+Test.@test occursin("must be positive", err.msg)
+```
+
+## Anti-patterns
+
+```julia
+error("something went wrong")                 # ❌ untyped, vague
+throw(Exceptions.IncorrectArgument("bad"))    # ❌ no got/expected/suggestion
+throw(Exceptions.IncorrectArgument("already finalized"))  # ❌ should be PreconditionError
+throw(Exceptions.PreconditionError("n must be > 0"))      # ❌ should be IncorrectArgument
+```
+
+## Checklist
+
+- [ ] Exception type matches the situation (single value vs relational vs contract vs …).
+- [ ] Message clear and specific; `got`/`expected` set when applicable.
+- [ ] Actionable `suggestion`; `context` for non-trivial errors.
+- [ ] Fields valid for the chosen type (`reason` only on `PreconditionError`).
+- [ ] Covered by a `@test_throws`.

--- a/dev/philosophy/modules.md
+++ b/dev/philosophy/modules.md
@@ -1,0 +1,133 @@
+# Modules and qualification
+
+Submodule organization and import rules. Generic examples.
+
+## Principles
+
+1. **One submodule per responsibility**, in its own directory `src/<Name>/<Name>.jl`.
+2. **Package manifest exports nothing**: the top-level file only `include`s the
+   submodules and `using .Submodule`; it **exports nothing**.
+3. **Each submodule exports its public API**; internal helpers stay unexported and are
+   reached via full qualification.
+4. **Qualified external imports**: `using Pkg: Pkg` or `import Pkg.Sub`, never a bare
+   `using Pkg`.
+5. **Qualification everywhere**: call `Sub.function` / `Sub.Type`, never rely on
+   implicit scope.
+6. **One-way dependency flow (DAG)**: a low module never depends on a high one; no
+   cycles.
+
+## The submodule manifest
+
+Canonical structure of `src/<Name>/<Name>.jl`:
+
+```julia
+"""
+Module docstring — role, responsibilities, dependencies.
+"""
+module Name
+
+# 1. External-package imports (qualified)
+import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES   # macros: symbol import tolerated
+import CTBase.Exceptions                                # qualifies Exceptions.*
+using SomePackage: SomePackage                          # call SomePackage.*
+
+# 2. Sibling-submodule imports
+using ..Lower
+import ..Other as OtherAlias
+using ..Core: AbstractTag                               # pervasive symbol only
+
+# 3. Includes (internal dependency order)
+include(joinpath(@__DIR__, "abstract_types.jl"))
+include(joinpath(@__DIR__, "concrete.jl"))
+
+# 4. Exports — public API only
+export AbstractThing, Thing
+export build_thing
+
+end # module Name
+```
+
+Order: docstring → `module` → external imports → sibling imports → `include`s →
+`export`s → `end`.
+
+## Import styles (by preference)
+
+```julia
+using SomePackage: SomePackage   # ✅ preferred: only the name enters scope
+import CTBase.Exceptions         # ✅ qualifies the submodule
+import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES  # ✅ reserved for macros / pervasive symbols
+```
+
+Forbidden:
+
+```julia
+using SomePackage                       # ❌ pollutes scope
+using CTBase: AbstractModel, validate   # ❌ opaque origin at call sites
+```
+
+## Sibling imports
+
+```julia
+using ..Lower                # call Lower.f(...)
+import ..Core as CTCore      # alias on conflict or for readability
+using ..Core: AbstractTag    # single pervasive symbol (often an abstract type)
+```
+
+## Qualification at call sites
+
+```julia
+# ✅ explicit origin at every call
+function Strategies.metadata(::Type{<:Modelers.ADNLP})
+    return Strategies.StrategyMetadata(
+        Strategies.OptionDefinition(name=:backend, type=Symbol, default=:auto),
+    )
+end
+
+# ❌ where do StrategyMetadata, OptionDefinition come from?
+function metadata(::Type{<:ADNLP})
+    return StrategyMetadata(OptionDefinition(name=:backend, type=Symbol))
+end
+```
+
+Why: visible origin, safe refactors (only the `using ..X` line changes), no accidental
+shadowing, same rule for external and sibling symbols.
+
+## Two-level exports
+
+- **Submodule**: `export` for its public API; internals (`_helper`) unexported.
+- **Package (top-level)**: **no** `export`. Load submodules with `using .Submodule`;
+  users reach them via `Package.Submodule.sym`.
+
+```julia
+module MyPackage
+include(joinpath(@__DIR__, "Core", "Core.jl"));       using .Core
+include(joinpath(@__DIR__, "Systems", "Systems.jl")); using .Systems
+# NO exports here.
+end
+```
+
+User access:
+
+```julia
+using MyPackage                  # brings no symbols into scope
+MyPackage.Systems.AbstractThing  # qualified (recommended)
+
+using MyPackage.Systems          # opt-in: brings Systems exports into scope
+AbstractThing                    # unqualified, the user's choice
+```
+
+## Dependency DAG
+
+The loading order in the top-level manifest follows a topological sort. A module may
+`using ..Lower` only if `Lower` is already loaded. **No cycles**: if two modules need
+each other, extract the shared concept into a lower module (`Core`).
+
+## Checklist
+
+- [ ] One submodule = one directory + one same-named manifest.
+- [ ] Manifest = docstring, `module`, imports, `include`s, `export`s, `end` — nothing else.
+- [ ] External imports: `using Pkg: Pkg` / `import Pkg.Sub` / (macros) `import Pkg: m`.
+- [ ] Sibling imports: `using ..Sib` / `import ..Sib as A` / `using ..Sib: Sym`.
+- [ ] Every external/sibling symbol is qualified at the call site.
+- [ ] Acyclic DAG respected by the loading order.
+- [ ] Each submodule exports its API; the package top-level exports nothing.

--- a/dev/philosophy/testing.md
+++ b/dev/philosophy/testing.md
@@ -1,0 +1,126 @@
+# Testing
+
+How tests are structured and written. Generic examples. For *running* tests, see
+[`../RULES.md`](../RULES.md).
+
+## Principles
+
+1. **Contract-first** — define and test contracts (interfaces) with fakes/stubs to
+   verify routing and behavior. Test public APIs and internal logic that matters.
+2. **Orthogonality** — test organization follows *functionality*, not the `src/` layout.
+3. **Isolation** — unit tests use fakes; integration tests exercise real boundaries.
+4. **Determinism** — reproducible, no external state, no execution-order dependence.
+5. **Clarity** — intent obvious from names and structure.
+
+## The file template (module + callable entry + qualified imports)
+
+This is mandatory. Each test file is a **module**; it imports everything **qualified**;
+it defines a single entry function `test_<name>()`; and it **redefines that function in
+the outer scope** so the test runner can call it.
+
+```julia
+# File: test/suite/<group>/test_<name>.jl
+module TestName
+
+# Qualified imports — bring module names into scope, call Sub.sym everywhere
+import Test
+import CTBase.Exceptions: Exceptions
+import MyPackage.SubA: SubA
+import MyPackage.SubB: SubB
+
+# Test options (verbose / timing), overridable by the runner
+const VERBOSE    = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE    : true
+const SHOWTIMING = isdefined(Main, :TestOptions) ? Main.TestOptions.SHOWTIMING : true
+
+# TOP-LEVEL fakes (never inside a function — world-age issues otherwise)
+struct FakeThing <: SubA.AbstractThing end
+SubA.required_method(::FakeThing) = 42
+
+# Single entry function, named exactly like the file
+function test_name()
+    Test.@testset "Name" verbose=VERBOSE showtiming=SHOWTIMING begin
+        Test.@test SubA.required_method(FakeThing()) == 42
+    end
+end
+
+end # module TestName
+
+# CRITICAL: redefine in the outer scope so the runner can call it
+test_name() = TestName.test_name()
+```
+
+Why each part:
+- **Module wrapper** — isolates names per file; avoids clashes across the suite.
+- **Qualified imports** (`import X: X`) — the module name is in scope, call sites read
+  `SubA.sym`; same policy as the source (see [`modules.md`](modules.md)).
+- **Top-level fakes** — defining a `struct` inside a function triggers world-age errors.
+- **Outer redefinition** — the runner discovers and calls `test_name()` at top level.
+
+## Test categories
+
+- **Fake** — minimal struct implementing the required contract methods, to isolate the
+  unit under test.
+- **Stub** — a default method on an abstract type that throws `NotImplemented` /
+  `ExtensionError`; tested by calling it on a fake type.
+- **Mock** (interaction-recording) — not used; fakes suffice.
+
+### Unit
+
+Single component in isolation; pure, deterministic, fast (<1ms). Use fakes for
+dependencies.
+
+### Integration
+
+Several real module boundaries together; fakes only for leaf dependencies. Slower
+(up to ~1s) acceptable.
+
+### Contract
+
+Verify the interface using fakes that implement only the required methods. Check
+routing, defaults, and Liskov substitution (generic code works for every subtype).
+
+### Error
+
+Verify stubs and error paths throw the right exception.
+
+- **Interface stub** (`NotImplemented`): a fake that omits a required method triggers
+  the abstract type's stub. Safe regardless of loaded extensions.
+- **Extension stub** (`ExtensionError` / fallback): **always use a fake type** no
+  extension knows about — using a real type makes the test depend on whether another
+  test file loaded the extension.
+
+Separate categories with section comments inside one `@testset`.
+
+## Critical rules
+
+1. **Structs at module top-level** — never inside test functions.
+2. **Qualified calls, omit the root for submodules** — `Test.@test SubA.f(x) isa
+   SubB.T` (not the fully-root-qualified, over-verbose form; not unqualified).
+3. **Export verification** — assert submodule exports exist and that the package
+   top-level re-exports nothing it shouldn't.
+4. **Test internal `_` functions** when logic is complex/branchy; otherwise cover them
+   indirectly.
+5. **Independence** — fresh instances per testset; no shared mutable/global state; no
+   order dependence.
+
+## Quality
+
+- Specific assertions (`≈ … atol=…`, `isa T`, `== n`), not `> 0` or `!= nothing`.
+- Names describe *what* is tested, not *how*.
+- Type-stability tests with `@inferred` on **function calls** (not field access);
+  allocation tests with `@allocated` for hot paths.
+
+```julia
+Test.@test_nowarn Test.@inferred SubA.accessor(obj)   # ✅ a call
+# Test.@inferred obj.field                              # ❌ field access
+Test.@test (Test.@allocated SubA.accessor(obj)) == 0
+```
+
+## Checklist
+
+- [ ] File is a module; entry `test_<name>()`; redefined in the outer scope.
+- [ ] All imports qualified; all calls qualified (root omitted for submodules).
+- [ ] Fakes/stubs defined at module top-level.
+- [ ] Categories present and separated (unit / integration / contract / error).
+- [ ] Error paths use `@test_throws`; extension stubs use fake types.
+- [ ] Each test independent and deterministic; specific assertions; descriptive names.

--- a/dev/philosophy/types-traits-interfaces.md
+++ b/dev/philosophy/types-traits-interfaces.md
@@ -1,0 +1,166 @@
+# Types, traits, interfaces
+
+How we model variation: abstract types for *nouns*, trait-parameters for *adjectives*,
+dispatch via trait extraction. Generic examples.
+
+## The guiding rule
+
+> **One abstract type per real *noun*. One trait-parameter per orthogonal *axis*.**
+> Concrete types are reserved for genuinely different data layouts.
+
+- **Abstract type** — good for a *noun* ("what is it"), `is-a` relations, shared
+  methods. But: single inheritance only → combinatorial explosion across several
+  orthogonal axes.
+- **Trait (as a type parameter)** — good for an *adjective / capability*. Composes
+  freely, dispatched via an extractor.
+
+## Traits as type parameters
+
+A trait is a singleton type under a shared abstract trait. It is carried as a type
+parameter and read back with an extractor.
+
+```julia
+abstract type AbstractMode <: AbstractTrait end
+struct Eager <: AbstractMode end
+struct Lazy  <: AbstractMode end
+
+# The trait is a parameter of the noun's abstract type
+abstract type AbstractThing{M<:AbstractMode} end
+
+# Extractor: returns a type known at compile time
+mode(::AbstractThing{M}) where {M} = M
+
+# Aliases give back the readable per-variant names for dispatch
+const AbstractEagerThing = AbstractThing{Eager}
+const AbstractLazyThing  = AbstractThing{Lazy}
+```
+
+Adding an axis is adding a parameter, not multiplying the type tree.
+
+## When an axis becomes a type parameter (vs. stays an extracted trait)
+
+The criterion is not "is this axis important?" but:
+
+> **Does the axis change the contract visible to consumers of the abstract type?**
+> If yes → type parameter. If no → extracted trait only.
+
+- An axis that changes the **method signatures** the abstract type promises (e.g. number
+  or role of arguments) is structural: it propagates up through the hierarchy and belongs
+  as a type parameter.
+- An axis that only affects **how** a computation is performed *inside* a concrete type,
+  while both variants honour the same abstract contract, stays as an extracted trait on
+  the concrete type.
+
+A practical signal: **if an axis never propagates beyond one level of the hierarchy** —
+present on concrete types but absent from abstract types and their consumers — it is most
+likely an implementation detail, not a structural axis.
+
+## Dispatch via the trait (Holy trait pattern)
+
+Extract the trait, then re-dispatch on it:
+
+```julia
+function process(x::AbstractThing)
+    return _process(mode(x), x)        # extract, then re-dispatch
+end
+
+_process(::Type{Eager}, x) = ...       # eager branch
+_process(::Type{Lazy},  x) = ...       # lazy branch
+```
+
+This is **type-stable** when the trait is a type parameter: `mode(x)` is known at
+compile time, so the re-dispatch resolves statically; the extra call is inlined.
+
+⚠️ Pitfall: extracting a trait from a *runtime value* (not encoded in the type) makes
+the re-dispatch dynamic and breaks inference. Keep traits as type parameters.
+
+## Interfaces and contracts
+
+Define methods on abstract types; mark required ones with a `NotImplemented` stub so a
+subtype that forgets them fails loudly.
+
+```julia
+abstract type AbstractModel end
+
+"""Contract: every model implements `evaluate`."""
+function evaluate(m::AbstractModel, x)
+    throw(Exceptions.NotImplemented(
+        "evaluate not implemented";
+        required_method = "evaluate(::$(typeof(m)), x)",
+        suggestion      = "Define evaluate for your concrete model type",
+        context         = "AbstractModel contract",
+    ))
+end
+
+# Generic code works with any subtype (LSP)
+function optimize(m::AbstractModel, x0)
+    v = evaluate(m, x0)   # safe for any model honoring the contract
+    # ...
+end
+```
+
+Rules:
+- **Accept abstractions** in signatures (`build(::AbstractInput)`), not concrete types,
+  so users can extend without editing core code (OCP/DIP).
+- **Subtypes honor the contract** (LSP): same return shape across the hierarchy; test
+  generic code against all subtypes.
+- **Do not add an abstract type for a capability.** A capability (e.g. "supports AD")
+  is a *trait*, not a node in the hierarchy — adding `AbstractThingWithAD` collides with
+  the other axes under single inheritance.
+
+## When concrete types are justified
+
+Use a concrete type when the *data layout* genuinely differs (different fields), not to
+encode an adjective. Two concrete types with identical fields that differ only by a flag
+should be one parametric type with a trait parameter + aliases.
+
+## SOLID / DRY / KISS / YAGNI (condensed)
+
+- **SRP** — one responsibility per module/function/type. Red flags: names with "and",
+  functions > ~50 lines, branches handling unrelated concerns.
+- **OCP** — extend via new subtypes + dispatch, not by editing `isa`/`typeof` chains.
+- **LSP** — subtypes substitutable; consistent return types.
+- **ISP** — small focused interfaces; don't force unused methods on a type.
+- **DIP** — depend on abstract types; inject dependencies.
+- **DRY** — one representation per piece of knowledge; extract shared validation.
+- **KISS** — the simplest thing that works.
+- **YAGNI** — no speculative fields/features.
+
+Anti-patterns to avoid: God object, primitive obsession (use domain types), feature
+envy (put the method where the data is).
+
+## Type stability {#type-stability}
+
+Type-stable = return type inferable from input types at compile time. Typically
+10–100× faster than unstable code.
+
+- **Parametric, concrete fields** — `struct C{T}; data::Vector{T}; end`, never
+  `Vector{Any}` or an abstract field type.
+- **`NamedTuple` over `Dict`** for fixed-key, mixed-type records.
+- **No `Any` in hot paths**; avoid conditional return types
+  (`Union{Int,Nothing}` from one function).
+- **Function barriers** — isolate an unavoidable instability behind a typed inner
+  function.
+- **`const Ref(...)`** instead of mutable globals.
+
+Verify:
+
+```julia
+@testset "type stability" begin
+    @test_nowarn @inferred f(x)      # @inferred only on function calls, not field access
+    @test (@allocated hot_path(x)) == 0
+end
+```
+
+Type stability matters on critical paths (inner loops, numerics); it is secondary on
+one-time setup, user-facing API, and error paths.
+
+## Checklist
+
+- [ ] One abstract type per noun; one trait-parameter per orthogonal axis.
+- [ ] Trait extractor + alias per variant; dispatch via extracted trait.
+- [ ] Contracts are `NotImplemented` stubs on abstract types.
+- [ ] Signatures accept abstractions; subtypes honor the contract.
+- [ ] No abstract type encoding a capability (use a trait).
+- [ ] Concrete types only for genuinely different data layouts.
+- [ ] Parametric concrete fields; no `Any` in hot paths; `@inferred` on critical calls.

--- a/dev/planning.md
+++ b/dev/planning.md
@@ -1,0 +1,119 @@
+# Implementation plan template
+
+A generic template for structuring a development task. Keep plans simple — the goal is
+to align with the human before touching code, not to produce a 50-step document.
+
+## When to write a plan
+
+Before any task that:
+- touches more than one file,
+- changes a public interface, or
+- involves a non-obvious design decision.
+
+Write the plan, share it, wait for confirmation before starting.
+
+---
+
+## Template
+
+```
+# Plan: <short title>
+
+## What and why
+<2-3 sentences: what changes, why now, what it unblocks.>
+
+## Scope
+- Files added: …
+- Files modified: …
+- Files deleted: …
+- Public API changes: yes / no (describe if yes)
+
+## Phases
+
+### Phase A — <name>
+Steps:
+1. …
+2. …
+Checkpoint: run `test/suite/<group>` via MCP. All green before moving on.
+
+### Phase B — <name>
+Steps:
+1. …
+Checkpoint: run `test/suite/<group>` + full suite.
+
+…
+
+## Human checkpoints
+- ⛔ Ask before first commit.
+- ⛔ Ask before pushing to a shared branch.
+- ⛔ Ask before deleting files that were not created in this task.
+- ⛔ Ask if a design decision arises that was not in the plan.
+
+## Out of scope
+<List things explicitly not done in this task.>
+```
+
+---
+
+## Rules for filling in the template
+
+**Phases** — one phase = one coherent unit that can be tested independently. A phase
+ends with a test checkpoint (run the affected test suite via the MCP `get_test_command`
+tool, then `generate_report`). Never skip the checkpoint.
+
+**Steps** — file-level granularity. "Edit `src/X/y.jl` to add method `f`" not "implement
+the feature". Concrete enough that a step is either done or not.
+
+**Human checkpoints** — mandatory stops. The human decides whether to commit, push, or
+proceed after a design change. The ⛔ symbol marks these explicitly so they are not
+missed.
+
+**Docstrings** — always the last step of the last phase, once the API is stable.
+
+**Out of scope** — explicit. Prevents scope creep and clarifies what the human should
+not expect after the plan is executed.
+
+---
+
+## Concrete example structure (abbreviated)
+
+```
+# Plan: rename content → dynamics trait
+
+## What and why
+Rename AbstractContentTrait and its values to AbstractDynamicsTrait / StateDynamics /
+HamiltonianDynamics / AugmentedHamiltonianDynamics. "content" is too neutral; "dynamics"
+names the axis. Purely mechanical, no behavior change.
+
+## Scope
+- Files modified: src/Traits/content.jl (rename to dynamics.jl), src/Traits/Traits.jl,
+  src/Configs/*, src/Solutions/building.jl, docs/api_reference.jl
+- Files renamed: test/suite/traits/test_content.jl → test_dynamics.jl
+- Public API changes: yes — AbstractContentTrait → AbstractDynamicsTrait (+ values)
+
+## Phases
+
+### Phase A — Rename Traits module
+Steps:
+1. Rename src/Traits/content.jl → dynamics.jl; update all names inside.
+2. Update include path in src/Traits/Traits.jl; update exports.
+Checkpoint: test/suite/traits — all green.
+
+### Phase B — Adapt consumers (Configs, Solutions)
+Steps:
+1. Update src/Configs/* (content_trait → dynamics_trait, value names).
+2. Update src/Solutions/building.jl.
+Checkpoint: test/suite/configs + test/suite/solutions — all green.
+
+### Phase C — Tests + docs
+Steps:
+1. Rename and update test/suite/traits/test_content.jl → test_dynamics.jl.
+2. Update docs/api_reference.jl file list.
+Checkpoint: full suite green.
+
+## Human checkpoints
+- ⛔ Ask before commit after Phase C.
+
+## Out of scope
+Parametrizing AbstractSystem/AbstractFlow by the dynamics trait (see action_plan.md Phase C/D).
+```

--- a/docs/api_reference.jl
+++ b/docs/api_reference.jl
@@ -62,6 +62,7 @@ function generate_api_reference(src_dir::String, ext_dir::String)
             subdirectory=".",
             primary_modules=[
                 CTModels.OCP => src(
+                    joinpath("OCP", "OCP.jl"),
                     joinpath("OCP", "aliases.jl"),
                     joinpath("OCP", "Types", "components.jl"),
                     joinpath("OCP", "Types", "model.jl"),
@@ -90,6 +91,7 @@ function generate_api_reference(src_dir::String, ext_dir::String)
                     joinpath("OCP", "Components", "dynamics.jl"),
                     joinpath("OCP", "Components", "objective.jl"),
                     joinpath("OCP", "Components", "constraints.jl"),
+                    joinpath("OCP", "Components", "definition.jl"),
                 ),
             ],
             external_modules_to_document=[CTModels],
@@ -112,7 +114,6 @@ function generate_api_reference(src_dir::String, ext_dir::String)
                     joinpath("OCP", "Building", "interpolation_helpers.jl"),
                     joinpath("OCP", "Building", "discretization_utils.jl"),
                     joinpath("OCP", "Building", "dual_model.jl"),
-                    joinpath("OCP", "Building", "definition.jl"),
                 ),
             ],
             external_modules_to_document=[CTModels],
@@ -149,8 +150,14 @@ function generate_api_reference(src_dir::String, ext_dir::String)
         CTBase.automatic_reference_documentation(;
             subdirectory=".",
             primary_modules=[
-                CTModels.Display =>
-                    src(joinpath("Display", "Display.jl"), joinpath("Display", "print.jl")),
+                CTModels.Display => src(
+                    joinpath("Display", "Display.jl"),
+                    joinpath("Display", "ansi.jl"),
+                    joinpath("Display", "definition.jl"),
+                    joinpath("Display", "mathematical.jl"),
+                    joinpath("Display", "model.jl"),
+                    joinpath("Display", "pre_model.jl"),
+                ),
                 CTModelsPlots =>
                     ext("CTModelsPlots.jl", "plot.jl", "plot_utils.jl", "plot_default.jl"),
             ],
@@ -172,6 +179,7 @@ function generate_api_reference(src_dir::String, ext_dir::String)
                     joinpath("Serialization", "Serialization.jl"),
                     joinpath("Serialization", "export_import.jl"),
                     joinpath("Serialization", "types.jl"),
+                    joinpath("Serialization", "reconstruction_helpers.jl"),
                 ),
                 CTModelsJSON => ext("CTModelsJSON.jl"),
                 CTModelsJLD => ext("CTModelsJLD.jl"),

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -60,7 +60,34 @@ with_api_reference(src_dir, ext_dir) do api_pages
                 asset("https://control-toolbox.org/assets/js/documentation.js"),
             ],
         ),
-        pages=["Introduction" => "index.md", "API Reference" => api_pages],
+        pages=[
+            "Introduction" => "index.md",
+            "Optimal control problems" => [
+                "Overview" => "model/index.md",
+                "Types and traits" => "model/types_and_traits.md",
+                "Components" => "model/components.md",
+                "Dynamics and objective" => "model/dynamics_objective.md",
+                "Constraints" => "model/constraints.md",
+                "Building a model" => "model/building.md",
+            ],
+            "Solutions" => [
+                "Overview" => "solution/index.md",
+                "Time grids" => "solution/time_grids.md",
+                "Trajectories" => "solution/trajectories.md",
+                "Duals & diagnostics" => "solution/duals.md",
+            ],
+            "Initial guesses" => [
+                "Overview" => "initial_guess/index.md",
+                "Input formats" => "initial_guess/formats.md",
+                "Validation & warm-start" => "initial_guess/validation.md",
+            ],
+            "Serialization & extensions" => [
+                "Overview" => "serialization/index.md",
+                "Export & import" => "serialization/export_import.md",
+                "Plotting" => "serialization/plotting.md",
+            ],
+            "API Reference" => api_pages,
+        ],
     )
 end
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,6 +59,9 @@ with_api_reference(src_dir, ext_dir) do api_pages
                 asset("https://control-toolbox.org/assets/css/documentation.css"),
                 asset("https://control-toolbox.org/assets/js/documentation.js"),
             ],
+            size_threshold_ignore=[
+                joinpath("api", "api_ocp_building_public.md"),
+            ],
         ),
         pages=[
             "Introduction" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,9 +59,7 @@ with_api_reference(src_dir, ext_dir) do api_pages
                 asset("https://control-toolbox.org/assets/css/documentation.css"),
                 asset("https://control-toolbox.org/assets/js/documentation.js"),
             ],
-            size_threshold_ignore=[
-                joinpath("api", "api_ocp_building_public.md"),
-            ],
+            size_threshold_ignore=["api_ocp_building_public.md"],
         ),
         pages=[
             "Introduction" => "index.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -75,6 +75,16 @@ At a high level, CTModels is responsible for:
 Most of the public API is organized in a way that closely mirrors the mathematical
 objects you manipulate when formulating an optimal control problem.
 
+## Module overview
+
+| Module | Responsibility |
+|--------|---------------|
+| `CTModels.OCP` | Types and builders for optimal control problems and solutions |
+| `CTModels.Utils` | Interpolation, matrix utilities, `@ensure` validation macro |
+| `CTModels.Display` | `Base.show` extensions for models and solutions |
+| `CTModels.Serialization` | `export_ocp_solution` / `import_ocp_solution` (JLD2, JSON) |
+| `CTModels.Init` | Initial guess construction and validation |
+
 ## Time grids and basic aliases
 
 CTModels defines a few central type aliases that appear throughout the API:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -179,33 +179,40 @@ The documentation consists of:
 
 - **Introduction** (this page): Overview of CTModels and its role in the control-toolbox ecosystem.
 
-- **API Reference**: Complete documentation of all modules and functions:
-  - *CTModels*: Main module and exports
-  - *Utils*: Utilities (interpolation, macros, matrix operations)
-  - *OCP*: Optimal Control Problem types, components, building, and validation
-  - *Display*: Text display and printing
-  - *Serialization*: Export/import functionality
-  - *InitialGuess*: Initial guess management
-  - *Extensions*: Plots, JSON, and JLD2 extensions
+- **Developer guides** — narrative, architecture-oriented walkthroughs aimed at
+  control-toolbox contributors:
+  - [Optimal control problems](model/index.md): the `PreModel → build → Model` pipeline,
+    types & traits, components, dynamics, objective, constraints.
+  - [Solutions](solution/index.md): the `Solution` anatomy, time grids, trajectories, duals.
+  - [Initial guesses](initial_guess/index.md): the `Init` pipeline and warm-starting.
+  - [Serialization & extensions](serialization/index.md): export/import and plotting.
 
-Use the **API Reference** to look up the details of particular functions and types.
+- **API Reference**: Auto-generated, exhaustive documentation of every module and symbol
+  (public *and* private), one page per submodule and loaded extension.
+
+Use the **guides** to learn how the pieces fit together, and the **API Reference** to look up
+the details of a particular function or type.
 
 ## Quick start guide
 
 - **I want to define an optimal control problem**  
-  See **API Reference → OCP Components** for `state!`, `control!`, `dynamics!`, `objective!`, `constraint!`, etc.
-  
+  See the [Optimal control problems](model/index.md) guide for `state!`, `control!`,
+  `dynamics!`, `objective!`, `constraint!`, and `build`.
+
+- **I want to read a solution**  
+  See the [Solutions](solution/index.md) guide for `state`, `control`, `costate`, `dual`, and
+  the solver diagnostics.
+
 - **I want to build initial guesses**  
-  See **API Reference → InitialGuess** for `pre_initial_guess`, `initial_guess`, and `build_initial_guess`.
-  
-- **I want to save/load solutions**  
-  See **API Reference → Serialization** and the JSON/JLD2 extension pages for `export_ocp_solution` and `import_ocp_solution`.
-  
-- **I want to plot solution trajectories**  
-  See **API Reference → Plots Extension** for `plot(sol)` and `plot!(sol)` with `Plots.jl`.
-  
+  See the [Initial guesses](initial_guess/index.md) guide for `pre_initial_guess`,
+  `initial_guess`, and `build_initial_guess`.
+
+- **I want to save/load or plot solutions**  
+  See the [Serialization & extensions](serialization/index.md) guide for `export_ocp_solution`,
+  `import_ocp_solution`, and `plot(sol)`.
+
 - **I want to solve an optimal control problem**  
   Use [CTSolvers.jl](https://github.com/control-toolbox/CTSolvers.jl) which provides discretization, NLP backends, and optimization strategies.
-  
+
 - **I use OptimalControl.jl**  
   CTModels provides the underlying types and building blocks. OptimalControl.jl offers a higher-level interface.

--- a/docs/src/initial_guess/formats.md
+++ b/docs/src/initial_guess/formats.md
@@ -1,0 +1,76 @@
+# Input formats
+
+```@meta
+CurrentModule = CTModels
+```
+
+Each component of an initial guess (state, control, variable) accepts several shapes. CTModels
+normalises them all to a **callable of time**, so the rest of the stack sees one interface.
+
+| Per-component input | Interpreted as |
+|---|---|
+| a function `t -> …` | used directly |
+| a vector `[a, b, …]` | the constant trajectory `t -> [a, b, …]` |
+| a scalar (dim-1 component) | the constant trajectory `t -> [a]` |
+| `nothing` | a built-in default |
+
+```@example fmt
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+nothing # hide
+```
+
+## Functions
+
+The most general form — a time-varying guess:
+
+```@example fmt
+init = CTModels.build_initial_guess(ocp,
+    (state = t -> [cos(t), -sin(t)], control = t -> [0.5 * t]))
+(init.state(0.0), init.state(1.0), init.control(1.0))
+```
+
+## Constants
+
+A vector (or a scalar for a one-dimensional component) is broadcast to a **constant**
+trajectory:
+
+```@example fmt
+init = CTModels.build_initial_guess(ocp, (state = [0.0, 1.0], control = 0.1))
+(init.state(0.0), init.state(0.9), init.control(0.5))   # constant in time
+```
+
+## Defaults
+
+Omitting a component (or passing `nothing` / `()`) yields the built-in default guess, sized to
+the problem:
+
+```@example fmt
+init = CTModels.build_initial_guess(ocp, ())
+(init.state(0.5), init.control(0.5))
+```
+
+## Pre-initialisation
+
+[`pre_initial_guess`](@ref CTModels.Init.pre_initial_guess) packages raw, **model-independent**
+data into a [`PreInitialGuess`](@ref CTModels.Init.PreInitialGuess); the model is only needed
+later when [`build_initial_guess`](@ref CTModels.Init.build_initial_guess) validates it:
+
+```@example fmt
+pre_ig = CTModels.pre_initial_guess(state = t -> [0.0, 0.0], control = t -> [1.0])
+init   = CTModels.build_initial_guess(ocp, pre_ig)
+init.control(0.25)
+```
+
+How the dimensions are checked, and how to warm-start from a previous solution, is covered in
+[Validation & warm-start](validation.md).
+```

--- a/docs/src/initial_guess/index.md
+++ b/docs/src/initial_guess/index.md
@@ -1,0 +1,66 @@
+# Initial guesses
+
+```@meta
+CurrentModule = CTModels
+```
+
+The [`CTModels.Init`](@ref CTModels.Init) submodule builds **initial guesses** — starting
+trajectories for state, control and variable that warm-start a numerical solver. A good guess
+is often decisive on hard problems.
+
+`Init` separates *construction* from *validation* through a small pipeline:
+
+```
+raw data ──► pre_initial_guess / initial_guess ──► InitialGuess (unvalidated)
+                                                          │
+                                          validate_initial_guess (against the model)
+                                                          ▼
+                                                 InitialGuess (validated)
+```
+
+[`build_initial_guess`](@ref CTModels.Init.build_initial_guess) is the **single entry point**
+that does both: it accepts many input formats, converts them, and validates dimensions against
+the [`Model`](@ref CTModels.OCP.Model).
+
+## Reading order
+
+| Page | Topic | Key symbols |
+|---|---|---|
+| [Input formats](formats.md) | What you can pass per component | [`initial_guess`](@ref CTModels.Init.initial_guess), [`pre_initial_guess`](@ref CTModels.Init.pre_initial_guess) |
+| [Validation & warm-start](validation.md) | Dimension checks and reuse | [`build_initial_guess`](@ref CTModels.Init.build_initial_guess), [`validate_initial_guess`](@ref CTModels.Init.validate_initial_guess) |
+
+## Accepted inputs to `build_initial_guess`
+
+| Input | Meaning |
+|---|---|
+| `nothing` / `()` | default guess |
+| [`InitialGuess`](@ref CTModels.Init.InitialGuess) | validated as-is |
+| [`PreInitialGuess`](@ref CTModels.Init.PreInitialGuess) | converted, then validated |
+| [`Solution`](@ref CTModels.OCP.Solution) | warm-start from a previous solve |
+| `NamedTuple` | `(state=…, control=…, variable=…)` |
+
+## Minimal example
+
+```@example init_index
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+init = CTModels.build_initial_guess(ocp, (state=t -> [0.0, 0.0], control=t -> [0.1]))
+```
+
+The result is a validated [`InitialGuess`](@ref CTModels.Init.InitialGuess) whose components
+are callables of time:
+
+```@example init_index
+(init.state(0.5), init.control(0.5))
+```
+```

--- a/docs/src/initial_guess/validation.md
+++ b/docs/src/initial_guess/validation.md
@@ -1,0 +1,76 @@
+# Validation & warm-start
+
+```@meta
+CurrentModule = CTModels
+```
+
+[`build_initial_guess`](@ref CTModels.Init.build_initial_guess) always ends with a dimension
+check against the model. The check can also be invoked on its own with
+[`validate_initial_guess`](@ref CTModels.Init.validate_initial_guess), and a guess can be
+**warm-started** from a previous [`Solution`](@ref CTModels.OCP.Solution).
+
+```@example val
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+nothing # hide
+```
+
+## Construct, then validate
+
+[`initial_guess`](@ref CTModels.Init.initial_guess) builds an **unvalidated**
+[`InitialGuess`](@ref CTModels.Init.InitialGuess); pass it to
+[`validate_initial_guess`](@ref CTModels.Init.validate_initial_guess) to check it against the
+model. This separation lets a caller build once and validate against several models.
+
+```@example val
+ig = CTModels.initial_guess(ocp; state = t -> [0.0, 0.0], control = t -> [0.1])
+ig === CTModels.validate_initial_guess(ocp, ig)   # returns the same object when valid
+```
+
+## Dimension mismatch is rejected
+
+Validation samples the guess and compares its shape to the problem dimensions. A state guess
+of the wrong length is refused:
+
+```@example val
+try
+    CTModels.build_initial_guess(ocp, (state = t -> [0.0],))   # 1 ≠ 2 states
+catch e
+    (e isa CTModels.OCP.Exceptions.IncorrectArgument, :rejected)
+end
+```
+
+## Warm-start from a solution
+
+Passing a [`Solution`](@ref CTModels.OCP.Solution) reuses its trajectories as the new guess —
+the standard *warm-start*. The state/control dimensions must match between the solution's model
+and the target model.
+
+```@example val
+# A (fabricated) solution of the same problem
+N = 51
+T = collect(range(0.0, 1.0; length=N))
+X = hcat(cos.(T), -sin.(T))
+U = reshape(-cos.(T), N, 1)
+P = zeros(N, 2)
+sol = CTModels.build_solution(ocp, T, X, U, Float64[], P;
+    objective=0.5, iterations=10, constraints_violation=1e-9,
+    message="ok", status=:optimal, successful=true)
+
+# Reuse it as an initial guess
+warm = CTModels.build_initial_guess(ocp, sol)
+warm.state(0.5)
+```
+
+The warm-started guess is a validated [`InitialGuess`](@ref CTModels.Init.InitialGuess), ready
+to seed the next solve.
+```

--- a/docs/src/model/building.md
+++ b/docs/src/model/building.md
@@ -1,0 +1,83 @@
+# Building a model
+
+```@meta
+CurrentModule = CTModels
+```
+
+[`build`](@ref CTModels.OCP.build) turns a fully-declared, mutable
+[`PreModel`](@ref CTModels.OCP.PreModel) into an **immutable**
+[`Model`](@ref CTModels.OCP.Model). `build_model` is an alias of `build`.
+
+## Prerequisites
+
+Before building, the pre-model must be **consistent**: times, state, complete dynamics,
+objective and the time-dependence flag must all be set. The check is
+[`__is_consistent`](@ref CTModels.OCP.__is_consistent); `build` raises a structured error if
+a piece is missing. Control and variable are optional — their absence is represented by the
+[`EmptyControlModel`](@ref CTModels.OCP.EmptyControlModel) /
+[`EmptyVariableModel`](@ref CTModels.OCP.EmptyVariableModel) sentinels.
+
+Two extra declarations complete the problem:
+
+- [`time_dependence!`](@ref CTModels.OCP.time_dependence!) — marks the system
+  `autonomous=true|false` (sets the [`TimeDependence`](@ref CTModels.OCP.TimeDependence) trait);
+- [`definition!`](@ref CTModels.OCP.definition!) — *optional* — attaches the symbolic
+  problem definition (a Julia `Expr`) as a [`Definition`](@ref CTModels.OCP.Definition);
+  without it the model carries an [`EmptyDefinition`](@ref CTModels.OCP.EmptyDefinition).
+
+```@example building
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+
+ocp = CTModels.build(pre)
+```
+
+## What a built `Model` guarantees
+
+Building freezes the structure and exposes it through accessors. Because every component is
+a concrete typed field, queries are type-stable and need no closure inspection:
+
+```@example building
+(CTModels.state_dimension(ocp),
+ CTModels.control_dimension(ocp),
+ CTModels.variable_dimension(ocp),
+ CTModels.initial_time(ocp),
+ CTModels.final_time(ocp),
+ CTModels.is_autonomous(ocp),
+ CTModels.has_lagrange_cost(ocp))
+```
+
+Missing a required piece is caught at build time:
+
+```@example building
+incomplete = CTModels.PreModel()
+CTModels.state!(incomplete, 1)
+try
+    CTModels.build(incomplete)        # no times, dynamics, objective…
+catch e
+    typeof(e)
+end
+```
+
+## Where `build` sits in the pipeline
+
+```
+PreModel ──validate──► consistent? ──freeze──► Model
+   │                       │                      │
+state!/…              __is_consistent        immutable, typed
+time_dependence!      name uniqueness        accessor surface
+definition! (opt.)    dynamics complete
+```
+
+The immutable `Model` is the object every downstream package consumes: it is the input to
+[Solutions](../solution/index.md), [Initial guesses](../initial_guess/index.md) and
+[Serialization](../serialization/index.md).
+```

--- a/docs/src/model/components.md
+++ b/docs/src/model/components.md
@@ -1,0 +1,96 @@
+# Components
+
+```@meta
+CurrentModule = CTModels
+```
+
+The four declaration verbs populate the spaces of the problem on a
+[`PreModel`](@ref CTModels.OCP.PreModel). Each may be called **once**; calling it twice, or
+with inconsistent dimensions, raises a structured exception.
+
+| Verb | Declares | Stores into `pre.…` |
+|---|---|---|
+| [`state!`](@ref CTModels.OCP.state!) | state space ``x \in \mathbb{R}^n`` | `pre.state` |
+| [`control!`](@ref CTModels.OCP.control!) | control space ``u \in \mathbb{R}^m`` | `pre.control` |
+| [`variable!`](@ref CTModels.OCP.variable!) | optimisation variable ``v \in \mathbb{R}^q`` | `pre.variable` |
+| [`time!`](@ref CTModels.OCP.time!) | the interval ``[t_0, t_f]`` | `pre.times` |
+
+```@example components
+using CTModels
+pre = CTModels.PreModel()
+nothing # hide
+```
+
+## Dimension, name and components
+
+A space has a **dimension**, a **display name**, and per-**component** names. Omitted names
+are generated (`"x"`, then `"x₁", "x₂", …`). Each declaration accepts `String` or `Symbol`.
+
+```@example components
+CTModels.state!(pre, 2, "x", ["q", "w"])
+
+(CTModels.dimension(pre.state),   # 2
+ CTModels.name(pre.state),        # "x"
+ CTModels.components(pre.state))  # ["q", "w"]
+```
+
+```@example components
+CTModels.control!(pre, 1)                 # default name "u"
+CTModels.components(pre.control)
+```
+
+## The optimisation variable
+
+[`variable!`](@ref CTModels.OCP.variable!) declares the time-independent decision variable
+``v`` (free final time, design parameters, …). A dimension of `0` means *no variable*:
+`pre.variable` then stays an [`EmptyVariableModel`](@ref CTModels.OCP.EmptyVariableModel).
+
+```@example components
+CTModels.variable!(pre, 2, "v")
+(CTModels.dimension(pre.variable), CTModels.components(pre.variable))
+```
+
+## Time: fixed and free ends
+
+[`time!`](@ref CTModels.OCP.time!) sets the interval. Each end is either **fixed** (a value
+`t0=`/`tf=`) or **free** (an index `ind0=`/`indf=` into ``v``, optimised by the solver).
+
+```@example components
+CTModels.time!(pre; t0=0.0, tf=1.0)        # both ends fixed
+(CTModels.time_name(pre.times),
+ CTModels.has_fixed_initial_time(pre.times),
+ CTModels.has_fixed_final_time(pre.times))
+```
+
+A **free final time** stored at index `2` of ``v`` (declared above with dimension 2):
+
+```@example components
+pre2 = CTModels.PreModel()
+CTModels.variable!(pre2, 2, "v")
+CTModels.time!(pre2; t0=0.0, indf=2)
+(CTModels.has_free_final_time(pre2.times), CTModels.final_time(pre2.times, [0.0, 1.5]))
+```
+
+For a free time the value is read from ``v``, hence
+[`final_time`](@ref CTModels.OCP.final_time) takes the variable vector. See
+[Types and traits](types_and_traits.md) for the `Fixed`/`Free` distinction.
+
+## Naming rules
+
+Names must be **unique across all components** of the problem. The validation
+([`OCP/Validation/`](building.md)) rejects empty names, duplicates within a declaration, and
+collisions with names already declared elsewhere:
+
+```@example components
+pre3 = CTModels.PreModel()
+CTModels.state!(pre3, 2, "x", ["a", "b"])
+try
+    CTModels.control!(pre3, 1, "a")   # "a" already names a state component
+catch e
+    e isa CTModels.OCP.Exceptions.IncorrectArgument
+end
+```
+
+These rules guarantee that a label like `:a` resolves unambiguously to one component when
+reading a solution or a constraint.
+```

--- a/docs/src/model/constraints.md
+++ b/docs/src/model/constraints.md
@@ -1,0 +1,76 @@
+# Constraints
+
+```@meta
+CurrentModule = CTModels
+```
+
+[`constraint!`](@ref CTModels.OCP.constraint!) adds one constraint at a time to the
+pre-model. The first positional argument is the **kind**; the keywords give the bounds, the
+function or range, and a `label` used later to read back the constraint and its dual.
+
+| Kind | Form | Keywords |
+|---|---|---|
+| `:path` | nonlinear ``\ell \le c(t,x,u,v) \le u`` | `f`, `lb`, `ub`, `label` |
+| `:boundary` | nonlinear ``\ell \le b(x_0,x_f,v) \le u`` | `f`, `lb`, `ub`, `label` |
+| `:state` | box on state components | `rg`, `lb`, `ub`, `label` |
+| `:control` | box on control components | `rg`, `lb`, `ub`, `label` |
+| `:variable` | box on variable components | `rg`, `lb`, `ub`, `label` |
+
+Nonlinear constraint functions are written **in place** like the dynamics: `f(r, t, x, u, v)`
+for `:path`, `f(r, x0, xf, v)` for `:boundary`.
+
+```@example cons
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 2, "v")
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+
+# Nonlinear path and boundary constraints
+CTModels.constraint!(pre, :path;
+    f=(r, t, x, u, v) -> (r[1] = x[1] + u[1]; nothing), lb=[0.0], ub=[1.0], label=:p)
+CTModels.constraint!(pre, :boundary;
+    f=(r, x0, xf, v) -> (r[1] = x0[1]; r[2] = xf[1]; nothing),
+    lb=[0.0, 0.0], ub=[0.0, 0.0], label=:bc)
+
+# Box constraints on state, control and variable components
+CTModels.constraint!(pre, :state;    rg=1:1, lb=[-1.0], ub=[1.0], label=:x1)
+CTModels.constraint!(pre, :control;  rg=1:1, lb=[-10.0], ub=[10.0], label=:u)
+CTModels.constraint!(pre, :variable; rg=1:2, lb=[0.0, 0.0], ub=[1.0, 1.0], label=:vbox)
+
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+```
+
+## Reading constraints back
+
+On the built [`Model`](@ref CTModels.OCP.Model), the constraints are grouped in a
+[`ConstraintsModel`](@ref CTModels.OCP.ConstraintsModel) and queried by dimension or by label:
+
+```@example cons
+(CTModels.dim_path_constraints_nl(ocp),
+ CTModels.dim_boundary_constraints_nl(ocp),
+ CTModels.dim_state_constraints_box(ocp),
+ CTModels.dim_control_constraints_box(ocp),
+ CTModels.dim_variable_constraints_box(ocp))
+```
+
+## Labels and aliases
+
+Before building, constraints live in a [`ConstraintsDictType`](@ref CTModels.OCP.ConstraintsDictType)
+keyed by `label`. Box constraints obey a **per-component uniqueness invariant**: if several
+declarations touch the same component, their bounds are intersected and **all** their labels
+are kept as *aliases*. This is what lets [`constraint`](@ref CTModels.OCP.constraint) and
+[`dual`](@ref CTModels.OCP.dual) resolve any of the original labels to the merged component —
+see the [Duals](../solution/duals.md) guide.
+
+!!! note "One declaration, one label"
+
+    Always pass an explicit `label`. It is the stable handle for the constraint across
+    `build`, solution reconstruction, and dual extraction; auto-generated labels are harder
+    to track in downstream packages.
+```

--- a/docs/src/model/dynamics_objective.md
+++ b/docs/src/model/dynamics_objective.md
@@ -1,0 +1,90 @@
+# Dynamics and objective
+
+```@meta
+CurrentModule = CTModels
+```
+
+With the spaces declared, two verbs supply the **equations of motion** and the **cost**:
+[`dynamics!`](@ref CTModels.OCP.dynamics!) and
+[`objective!`](@ref CTModels.OCP.objective!).
+
+```@example dynobj
+using CTModels
+
+function fresh()                       # a pre-model with state, control, times set
+    pre = CTModels.PreModel()
+    CTModels.variable!(pre, 0)
+    CTModels.time!(pre; t0=0.0, tf=1.0)
+    CTModels.state!(pre, 2)
+    CTModels.control!(pre, 1)
+    return pre
+end
+nothing # hide
+```
+
+## Dynamics
+
+The right-hand side ``f`` of ``\dot{x} = f(t, x, u, v)`` is always written **in place**:
+the first argument `r` is the buffer to fill. The full signature is `f!(r, t, x, u, v)`,
+even for an autonomous system (the unused `t` keeps one uniform interface).
+
+```@example dynobj
+pre = fresh()
+function f!(r, t, x, u, v)
+    r[1] = x[2]
+    r[2] = u[1]
+    return nothing
+end
+CTModels.dynamics!(pre, f!)
+```
+
+### Component-wise dynamics
+
+Alternatively, define the dynamics **block by block** over disjoint state ranges. Each
+partial right-hand side fills its own local buffer (`r[1]` is the first row of its range).
+This is convenient when components come from different physical models.
+
+```@example dynobj
+pre = fresh()
+CTModels.dynamics!(pre, 1:1, (r, t, x, u, v) -> (r[1] = x[2]; nothing))
+CTModels.dynamics!(pre, 2:2, (r, t, x, u, v) -> (r[1] = u[1]; nothing))
+```
+
+The ranges must **tile** `1:n` without overlap; mixing the full form and the block form, or
+leaving a gap, raises an `Exceptions.PreconditionError`. The completeness check is
+[`__is_dynamics_complete`](@ref CTModels.OCP.__is_dynamics_complete), run by `build`.
+
+## Objective
+
+[`objective!`](@ref CTModels.OCP.objective!) takes the optimisation direction
+(`:min` or `:max`) and one or both of a **Mayer** term and a **Lagrange** term. The three
+combinations map to the three objective types of
+[Types and traits](types_and_traits.md):
+
+| Provided | Cost | Objective type |
+|---|---|---|
+| `lagrange` | ``\int_{t_0}^{t_f} f^0\,\mathrm{d}t`` | [`LagrangeObjectiveModel`](@ref CTModels.OCP.LagrangeObjectiveModel) |
+| `mayer` | ``g(x(t_0), x(t_f), v)`` | [`MayerObjectiveModel`](@ref CTModels.OCP.MayerObjectiveModel) |
+| both | Bolza: ``g + \int f^0`` | [`BolzaObjectiveModel`](@ref CTModels.OCP.BolzaObjectiveModel) |
+
+The Lagrange integrand has signature `f⁰(t, x, u, v)`; the Mayer term `g(x0, xf, v)`.
+
+```@example dynobj
+pre = fresh()
+CTModels.dynamics!(pre, f!)
+CTModels.objective!(pre, :min;
+    mayer    = (x0, xf, v) -> xf[1]^2,
+    lagrange = (t, x, u, v) -> u[1]^2,
+)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+(CTModels.criterion(ocp),
+ CTModels.has_mayer_cost(ocp),
+ CTModels.has_lagrange_cost(ocp))
+```
+
+Because the cost is stored as a typed object, downstream code dispatches on it (Mayer /
+Lagrange / Bolza) instead of inspecting closures — see the
+[Solutions](../solution/index.md) guide for how the objective **value** is read back.
+```

--- a/docs/src/model/index.md
+++ b/docs/src/model/index.md
@@ -1,0 +1,132 @@
+# Optimal control problems
+
+```@meta
+CurrentModule = CTModels
+```
+
+The [`CTModels.OCP`](@ref CTModels.OCP) submodule is the heart of CTModels: it defines and
+builds **optimal control problems** (OCPs). An OCP is assembled incrementally into a mutable
+[`PreModel`](@ref CTModels.OCP.PreModel), then frozen into an immutable
+[`Model`](@ref CTModels.OCP.Model) by [`build`](@ref CTModels.OCP.build).
+
+CTModels builds a model through a **three-stage pipeline**:
+
+```
+PreModel  →  declare components  →  build  →  Model
+(mutable)    state!/control!/...           (immutable)
+```
+
+The `OCP` submodule is organised by responsibility, each in its own subdirectory:
+
+| Layer | Subdirectory | What it provides |
+|---|---|---|
+| **Types** | `OCP/Types/` | Component, model and solution types ([`StateModel`](@ref CTModels.OCP.StateModel), [`Model`](@ref CTModels.OCP.Model), …) |
+| **Core** | `OCP/Core/` | Defaults and the [`TimeDependence`](@ref CTModels.OCP.TimeDependence) trait |
+| **Validation** | `OCP/Validation/` | Name-uniqueness checks across components |
+| **Components** | `OCP/Components/` | The `state!`, `control!`, `dynamics!`, … declaration verbs |
+| **Building** | `OCP/Building/` | [`build`](@ref CTModels.OCP.build) (model) and [`build_solution`](@ref CTModels.OCP.build_solution) |
+
+## Reading order
+
+| Page | Topic | Key symbols |
+|---|---|---|
+| [Types and traits](types_and_traits.md) | The noun/trait architecture | [`TimeDependence`](@ref CTModels.OCP.TimeDependence), `AbstractStateModel`, `Empty*` |
+| [Components](components.md) | Declaring the spaces | [`state!`](@ref CTModels.OCP.state!), [`control!`](@ref CTModels.OCP.control!), [`variable!`](@ref CTModels.OCP.variable!), [`time!`](@ref CTModels.OCP.time!) |
+| [Dynamics and objective](dynamics_objective.md) | The equations of motion and cost | [`dynamics!`](@ref CTModels.OCP.dynamics!), [`objective!`](@ref CTModels.OCP.objective!) |
+| [Constraints](constraints.md) | Path, boundary and box constraints | [`constraint!`](@ref CTModels.OCP.constraint!) |
+| [Building a model](building.md) | Freezing the `PreModel` | [`build`](@ref CTModels.OCP.build), [`Model`](@ref CTModels.OCP.Model) |
+
+## Qualified access
+
+CTModels exports nothing at the package level: every public symbol is reached through a
+qualified path `CTModels.symbol`. Bring the package into scope and call its verbs qualified:
+
+```@example model_index
+using CTModels
+nothing # hide
+```
+
+## Minimal end-to-end example
+
+We build the *beam* problem: minimise ``\int_0^1 u(t)^2\,\mathrm{d}t`` subject to
+``\dot{x} = (x_2, u)``, fixed boundary conditions, and box constraints on ``x_1`` and ``u``.
+
+```@example model_index
+# 1. A fresh, mutable pre-model
+pre = CTModels.PreModel()
+
+# 2. Declare the time interval, the spaces and (here) no optimisation variable
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)        # x ∈ ℝ²
+CTModels.control!(pre, 1)      # u ∈ ℝ
+
+# 3. Dynamics ẋ = (x₂, u), written in place
+function beam_dynamics!(r, t, x, u, v)
+    r[1] = x[2]
+    r[2] = u[1]
+    return nothing
+end
+CTModels.dynamics!(pre, beam_dynamics!)
+
+# 4. Lagrange cost ∫ u² → min
+beam_lagrange(t, x, u, v) = u[1]^2
+CTModels.objective!(pre, :min; lagrange=beam_lagrange)
+
+# 5. Boundary and box constraints
+function beam_boundary!(r, x0, xf, v)
+    r[1] = x0[1]      # x₁(0) = 0
+    r[2] = x0[2] - 1  # x₂(0) = 1
+    r[3] = xf[1]      # x₁(1) = 0
+    r[4] = xf[2] + 1  # x₂(1) = -1
+    return nothing
+end
+CTModels.constraint!(pre, :boundary; f=beam_boundary!, lb=zeros(4), ub=zeros(4), label=:bc)
+CTModels.constraint!(pre, :state;   rg=1:1, lb=[0.0],   ub=[0.1],  label=:x1_box)
+CTModels.constraint!(pre, :control; rg=1:1, lb=[-10.0], ub=[10.0], label=:u_box)
+
+# 6. Mark the system autonomous and freeze it into an immutable Model
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+```
+
+Once built, the `Model` answers queries through accessors:
+
+```@example model_index
+(CTModels.state_dimension(ocp),
+ CTModels.control_dimension(ocp),
+ CTModels.variable_dimension(ocp),
+ CTModels.is_autonomous(ocp))
+```
+
+The shortcut `CTModels.build_model(pre)` is an alias for `CTModels.build(pre)`; see
+[Building a model](building.md) for what `build` checks and guarantees.
+
+## Mathematical setting
+
+CTModels represents a continuous-time OCP in **Bolza form**. With state
+``x : [t_0, t_f] \to \mathbb{R}^n``, control ``u : [t_0, t_f] \to \mathbb{R}^m`` and an
+optimisation variable ``v \in \mathbb{R}^q`` (free final time, design parameters, …):
+
+```math
+\begin{aligned}
+\min_{x,\,u,\,v}\quad
+& g\big(x(t_0), x(t_f), v\big) + \int_{t_0}^{t_f} f^0\big(t, x(t), u(t), v\big)\,\mathrm{d}t \\
+\text{s.t.}\quad
+& \dot{x}(t) = f\big(t, x(t), u(t), v\big), \\
+& \text{path, boundary and box constraints.}
+\end{aligned}
+```
+
+Two **orthogonal axes** shape the representation:
+
+- **Time dependence** — whether ``f``, ``f^0`` depend explicitly on ``t``
+  ([`Autonomous`](@ref CTModels.OCP.Autonomous) vs
+  [`NonAutonomous`](@ref CTModels.OCP.NonAutonomous)).
+- **Time structure** — whether ``t_0`` / ``t_f`` are fixed or free
+  ([`FixedTimeModel`](@ref CTModels.OCP.FixedTimeModel) vs
+  [`FreeTimeModel`](@ref CTModels.OCP.FreeTimeModel)).
+
+How these axes become *traits* rather than separate types is the subject of
+[Types and traits](types_and_traits.md).
+```

--- a/docs/src/model/types_and_traits.md
+++ b/docs/src/model/types_and_traits.md
@@ -1,0 +1,104 @@
+# Types and traits
+
+```@meta
+CurrentModule = CTModels
+```
+
+This page explains the **type architecture** of the [`CTModels.OCP`](@ref CTModels.OCP)
+submodule, following the package tenet:
+
+!!! note "One abstract type per *noun*, one trait-parameter per *axis*"
+
+    Conceptual variants ("is this a state model or a control model?") are encoded as
+    **types**. Orthogonal yes/no axes ("autonomous?", "free final time?") are encoded as
+    **traits** carried in a type parameter, and selected by dispatch through an extractor.
+
+## Noun families
+
+Each *noun* of an OCP has one abstract supertype and a small family of concrete subtypes.
+The pattern is uniform: a *definition* type (structure only) and a *solution* type
+(structure + a numerical value), plus an *empty* sentinel where a component may be absent.
+
+| Abstract type | Definition | Solution | Empty sentinel |
+|---|---|---|---|
+| [`AbstractStateModel`](@ref CTModels.OCP.AbstractStateModel) | [`StateModel`](@ref CTModels.OCP.StateModel) | [`StateModelSolution`](@ref CTModels.OCP.StateModelSolution) | — |
+| [`AbstractControlModel`](@ref CTModels.OCP.AbstractControlModel) | [`ControlModel`](@ref CTModels.OCP.ControlModel) | [`ControlModelSolution`](@ref CTModels.OCP.ControlModelSolution) | [`EmptyControlModel`](@ref CTModels.OCP.EmptyControlModel) |
+| [`AbstractVariableModel`](@ref CTModels.OCP.AbstractVariableModel) | [`VariableModel`](@ref CTModels.OCP.VariableModel) | [`VariableModelSolution`](@ref CTModels.OCP.VariableModelSolution) | [`EmptyVariableModel`](@ref CTModels.OCP.EmptyVariableModel) |
+| [`AbstractTimeModel`](@ref CTModels.OCP.AbstractTimeModel) | [`FixedTimeModel`](@ref CTModels.OCP.FixedTimeModel) / [`FreeTimeModel`](@ref CTModels.OCP.FreeTimeModel) | — | — |
+| [`AbstractObjectiveModel`](@ref CTModels.OCP.AbstractObjectiveModel) | [`MayerObjectiveModel`](@ref CTModels.OCP.MayerObjectiveModel) / [`LagrangeObjectiveModel`](@ref CTModels.OCP.LagrangeObjectiveModel) / [`BolzaObjectiveModel`](@ref CTModels.OCP.BolzaObjectiveModel) | — | — |
+| [`AbstractDefinition`](@ref CTModels.OCP.AbstractDefinition) | [`Definition`](@ref CTModels.OCP.Definition) | — | [`EmptyDefinition`](@ref CTModels.OCP.EmptyDefinition) |
+
+The **empty sentinel** lets dispatch stay total: a control-free problem carries an
+`EmptyControlModel` rather than a `nothing`, so accessors like
+[`control_dimension`](@ref CTModels.OCP.control_dimension) return `0` without a special case.
+
+```@example types
+using CTModels
+
+sm  = CTModels.StateModel("x", ["x₁", "x₂"])
+evm = CTModels.EmptyVariableModel()
+
+(CTModels.dimension(sm), CTModels.name(sm), evm isa CTModels.OCP.AbstractVariableModel)
+```
+
+## The two trait axes
+
+Two orthogonal yes/no axes are **not** modelled as separate types but as traits.
+
+### Time dependence
+
+[`TimeDependence`](@ref CTModels.OCP.TimeDependence) has the two values
+[`Autonomous`](@ref CTModels.OCP.Autonomous) and
+[`NonAutonomous`](@ref CTModels.OCP.NonAutonomous). It is carried as the **first type
+parameter** of [`Model`](@ref CTModels.OCP.Model), so the distinction between
+``\dot{x} = f(x,u)`` and ``\dot{x} = f(t,x,u)`` is available at compile time. The extractor
+is [`is_autonomous`](@ref CTModels.OCP.is_autonomous):
+
+```@example types
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 1)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+CTModels.is_autonomous(ocp)
+```
+
+### Time structure
+
+Whether each end of the interval is fixed or free is the **type** of the corresponding
+[`AbstractTimeModel`](@ref CTModels.OCP.AbstractTimeModel) inside the
+[`TimesModel`](@ref CTModels.OCP.TimesModel). The extractors read the structure without
+exposing the concrete type:
+
+| Question | Extractor |
+|---|---|
+| Is ``t_0`` fixed / free? | [`has_fixed_initial_time`](@ref CTModels.OCP.has_fixed_initial_time) / [`has_free_initial_time`](@ref CTModels.OCP.has_free_initial_time) |
+| Is ``t_f`` fixed / free? | [`has_fixed_final_time`](@ref CTModels.OCP.has_fixed_final_time) / [`has_free_final_time`](@ref CTModels.OCP.has_free_final_time) |
+
+```@example types
+(CTModels.has_fixed_initial_time(ocp), CTModels.has_fixed_final_time(ocp))
+```
+
+A [`FreeTimeModel`](@ref CTModels.OCP.FreeTimeModel) stores the **index** into the
+optimisation variable ``v`` where the free time lives, rather than a value — see
+[Components](components.md).
+
+## Why traits, not twin types
+
+Modelling "autonomous vs non-autonomous" as two unrelated `Model` types would duplicate every
+method and break as soon as a third axis appears (the combinatorial explosion of
+2 × 2 × … types). Keeping each axis a trait-parameter means:
+
+- methods are written once on the abstract type and **dispatch only where the axis matters**;
+- adding an axis adds a parameter, not a new type hierarchy;
+- the public surface stays the *nouns* (`StateModel`, `Model`, …) and the *extractors*
+  (`is_autonomous`, `has_free_final_time`), never the raw parameters.
+
+This mirrors the ecosystem-wide design described in the package philosophy
+(`dev/philosophy/types-traits-interfaces.md`).
+```

--- a/docs/src/serialization/export_import.md
+++ b/docs/src/serialization/export_import.md
@@ -1,0 +1,81 @@
+# Export & import
+
+```@meta
+CurrentModule = CTModels
+```
+
+[`export_ocp_solution`](@ref CTModels.Serialization.export_ocp_solution) writes a
+[`Solution`](@ref CTModels.OCP.Solution) to disk;
+[`import_ocp_solution`](@ref CTModels.Serialization.import_ocp_solution) reads it back, given
+the [`Model`](@ref CTModels.OCP.Model) it belongs to. Two formats are available, each behind its
+extension:
+
+| `format` | Extension | File |
+|---|---|---|
+| `:JLD` (default) | `CTModelsJLD` (`JLD2`) | binary `.jld2` |
+| `:JSON` | `CTModelsJSON` (`JSON3`) | text `.json` |
+
+```@example exim
+using CTModels
+using JSON3      # CTModelsJSON
+using JLD2       # CTModelsJLD
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+N = 101
+T = collect(range(0.0, 1.0; length=N))
+sol = CTModels.build_solution(ocp, T, hcat(cos.(T), -sin.(T)),
+    reshape(-cos.(T), N, 1), Float64[], zeros(N, 2);
+    objective=0.5, iterations=10, constraints_violation=1e-9,
+    message="ok", status=:optimal, successful=true)
+nothing # hide
+```
+
+## Both formats round-trip
+
+The `filename` is a **base** path; the extension is appended automatically.
+
+```@example exim
+base = joinpath(tempdir(), "ctmodels_demo")
+
+CTModels.export_ocp_solution(sol; filename=base, format=:JSON)
+CTModels.export_ocp_solution(sol; filename=base, format=:JLD)
+
+from_json = CTModels.import_ocp_solution(ocp; filename=base, format=:JSON)
+from_jld  = CTModels.import_ocp_solution(ocp; filename=base, format=:JLD)
+
+(CTModels.objective(from_json), CTModels.objective(from_jld))
+```
+
+The reloaded solution behaves exactly like the original — its trajectories are again callables
+of time:
+
+```@example exim
+x = CTModels.state(from_json)
+x(0.5)
+```
+
+## How trajectories survive serialization
+
+A trajectory is a *function* `t -> x(t)`, which neither JSON nor JLD2 can store directly.
+CTModels works around this by **resampling**: before writing, each trajectory is evaluated on
+its time grid (the helpers in
+[`OCP/Building/discretization_utils.jl`](../model/building.md)), and only the resulting arrays
+are persisted. On import, the arrays are wrapped back into interpolated callables — the same
+mechanism used when [building a solution](../solution/trajectories.md).
+
+!!! note "Low-level tags"
+
+    The format keyword dispatches internally on the tags `CTModels.JSON3Tag()` and
+    `CTModels.JLD2Tag()`. The extension methods
+    `export_ocp_solution(CTModels.JLD2Tag(), sol; …)` etc. are what each `ext/` file
+    implements; the `format=` wrapper is the public, dependency-free entry point.
+```

--- a/docs/src/serialization/index.md
+++ b/docs/src/serialization/index.md
@@ -1,0 +1,78 @@
+# Serialization & extensions
+
+```@meta
+CurrentModule = CTModels
+```
+
+CTModels keeps heavy, optional dependencies out of its core. Saving solutions (JSON, JLD2) and
+plotting them live in **package extensions** under `ext/`, loaded automatically by Julia only
+when the trigger package is present.
+
+| Extension | Trigger package | Adds |
+|---|---|---|
+| `CTModelsJSON` | `JSON3` | JSON export/import of a [`Solution`](@ref CTModels.OCP.Solution) |
+| `CTModelsJLD` | `JLD2` | JLD2 (binary) export/import |
+| `CTModelsPlots` | `Plots` | `Plots.plot(sol)` / `Plots.plot!(sol)` |
+
+The public wrappers [`export_ocp_solution`](@ref CTModels.Serialization.export_ocp_solution),
+[`import_ocp_solution`](@ref CTModels.Serialization.import_ocp_solution) and the plot recipe
+live in the core; their **implementations** live in the extension. Until the trigger package is
+loaded, calling a wrapper raises a descriptive `CTBase.ExtensionError` — the core never hard-
+depends on JSON3, JLD2 or Plots.
+
+```
+core wrapper ──(trigger pkg loaded?)──► extension method
+     │                  │
+export_ocp_solution    no ─► CTBase.ExtensionError
+plot recipe            yes ─► JSON3 / JLD2 / Plots implementation
+```
+
+## Reading order
+
+| Page | Topic | Key symbols |
+|---|---|---|
+| [Export & import](export_import.md) | Persisting solutions | [`export_ocp_solution`](@ref CTModels.Serialization.export_ocp_solution), [`import_ocp_solution`](@ref CTModels.Serialization.import_ocp_solution) |
+| [Plotting](plotting.md) | Visualising trajectories | `Plots.plot`, `Plots.plot!` |
+
+## A solution to serialize
+
+The examples in this guide reuse one fabricated solution:
+
+```@example ser_index
+using CTModels
+using JSON3     # activates the CTModelsJSON extension
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+N = 101
+T = collect(range(0.0, 1.0; length=N))
+X = hcat(cos.(T), -sin.(T))
+U = reshape(-cos.(T), N, 1)
+P = zeros(N, 2)
+sol = CTModels.build_solution(ocp, T, X, U, Float64[], P;
+    objective=0.5, iterations=10, constraints_violation=1e-9,
+    message="ok", status=:optimal, successful=true)
+nothing # hide
+```
+
+## Round-trip in one line each
+
+```@example ser_index
+base = joinpath(tempdir(), "ctmodels_overview")
+CTModels.export_ocp_solution(sol; filename=base, format=:JSON)
+reloaded = CTModels.import_ocp_solution(ocp; filename=base, format=:JSON)
+
+(CTModels.objective(sol), CTModels.objective(reloaded))
+```
+
+See [Export & import](export_import.md) for the formats and the resampling strategy, and
+[Plotting](plotting.md) for the Plots recipe.
+```

--- a/docs/src/serialization/plotting.md
+++ b/docs/src/serialization/plotting.md
@@ -1,0 +1,69 @@
+# Plotting
+
+```@meta
+CurrentModule = CTModels
+```
+
+When `Plots` is loaded, the `CTModelsPlots` extension adds a recipe so a
+[`Solution`](@ref CTModels.OCP.Solution) can be drawn directly with `plot` / `plot!`. The
+recipe lays out the state, control, costate (and, when present, path constraints and their
+duals) on a shared time axis.
+
+```@example plt
+using CTModels
+using Plots      # activates the CTModelsPlots extension
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+N = 101
+T = collect(range(0.0, 1.0; length=N))
+sol = CTModels.build_solution(ocp, T, hcat(cos.(T), -sin.(T)),
+    reshape(-cos.(T), N, 1), Float64[], zeros(N, 2);
+    objective=0.5, iterations=10, constraints_violation=1e-9,
+    message="ok", status=:optimal, successful=true)
+nothing # hide
+```
+
+## Default plot
+
+```@example plt
+CTModels.plot(sol)
+```
+
+## Layout and control options
+
+The recipe accepts keyword arguments that control the arrangement and how the control is
+displayed:
+
+| Keyword | Values | Effect |
+|---|---|---|
+| `layout` | `:group` / `:split` | one figure per quantity, or state/costate split |
+| `control` | `:components` / `:norm` / `:all` | plot each control, its norm, or both |
+| `time` | `:default` / `:normalize` | physical time, or rescaled to ``[0, 1]`` |
+
+```@example plt
+CTModels.plot(sol; layout=:split, control=:all)
+```
+
+## Overlaying solutions
+
+`plot!` adds a solution to an existing figure — handy for comparing two solves on the same
+axes:
+
+```@example plt
+plt = CTModels.plot(sol)
+CTModels.plot!(plt, sol; time=:normalize)
+```
+
+Because the recipe reads the *typed* solution (its time grids, interpolation kind, and dual
+structure) rather than raw arrays, the same call works for unified- and multiple-grid
+solutions alike — see [Time grids](../solution/time_grids.md).
+```

--- a/docs/src/solution/duals.md
+++ b/docs/src/solution/duals.md
@@ -1,0 +1,93 @@
+# Duals & diagnostics
+
+```@meta
+CurrentModule = CTModels
+```
+
+Beyond the primal trajectories, a solution carries the **Lagrange multipliers** of the
+constraints (grouped in a [`DualModel`](@ref CTModels.OCP.DualModel)) and the **solver
+diagnostics** (a [`SolverInfos`](@ref CTModels.OCP.SolverInfos)).
+
+## A solution with duals
+
+We build a small problem with a boundary constraint and two path constraints, then supply the
+path-constraint multipliers as a callable `t → μ(t)`. State, control and costate are passed as
+**functions** here (the array form is equally accepted):
+
+```@example duals
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 1)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> -u[1])
+
+CTModels.constraint!(pre, :boundary;
+    f=(r, x0, xf, v) -> (r[1] = x0[1] + 1; nothing), lb=[0.0], ub=[0.0], label=:initial_con)
+CTModels.constraint!(pre, :path;
+    f=(r, t, x, u, v) -> (r[1] = x[1] + u[1]; nothing), lb=[-Inf], ub=[0.0])  # 1 row
+CTModels.constraint!(pre, :path;
+    f=(r, t, x, u, v) -> (r[1] = x[1] + 1; r[2] = u[1] + 1; nothing),
+    lb=[-3.0, 1.0], ub=[1.0, 2.5], label=:con2)                                # 2 rows
+
+CTModels.time_dependence!(pre; autonomous=false)
+ocp = CTModels.build(pre)
+
+x(t) = -exp(-t)
+p(t) = exp(t - 1) - 1
+u(t) = -x(t)
+mu(t) = [-(p(t) + 1), 0.0, t]      # one entry per stacked path-constraint row
+
+sol = CTModels.build_solution(ocp, collect(range(0.0, 1.0; length=201)),
+    x, u, Float64[], p;
+    objective=exp(-1) - 1, iterations=12, constraints_violation=0.0,
+    message="Solve_Succeeded", status=:optimal, successful=true,
+    path_constraints_dual=mu)
+nothing # hide
+```
+
+## Reading a multiplier by label
+
+[`dual`](@ref CTModels.OCP.dual) resolves a constraint `label` to its multiplier — a callable
+for time-dependent (path) constraints, a value for boundary/variable ones. The label `:con2`
+covers the **two** path rows declared with it, so its dual is the 2-vector slice:
+
+```@example duals
+d = CTModels.dual(sol, ocp, :con2)
+d(0.5)
+```
+
+The whole path multiplier is reached directly through the
+[`DualModel`](@ref CTModels.OCP.DualModel) accessor
+[`path_constraints_dual`](@ref CTModels.OCP.path_constraints_dual):
+
+```@example duals
+CTModels.path_constraints_dual(sol)(0.5)
+```
+
+!!! note "Box duals are indexed per component"
+
+    For state/control/variable **box** constraints, the stored duals are indexed by *primal
+    component*. `dual(sol, model, :label)` returns `duals_lb[:, rg] - duals_ub[:, rg]` for the
+    component range `rg` of the label. If several labels target the same component (the alias
+    mechanism of the [Constraints](../model/constraints.md) page), they share that one
+    multiplier — the solver only sees the intersected bound.
+
+## Solver diagnostics
+
+The [`SolverInfos`](@ref CTModels.OCP.SolverInfos) record is exposed through scalar accessors:
+
+```@example duals
+(CTModels.iterations(sol),
+ CTModels.status(sol),
+ CTModels.message(sol),
+ CTModels.successful(sol),
+ CTModels.constraints_violation(sol))
+```
+
+`infos(sol)` returns the `Dict{Symbol,Any}` of any extra solver-specific data. These fields
+are what [Serialization](../serialization/index.md) writes to disk alongside the trajectories.
+```

--- a/docs/src/solution/index.md
+++ b/docs/src/solution/index.md
@@ -1,0 +1,89 @@
+# Solutions
+
+```@meta
+CurrentModule = CTModels
+```
+
+A [`Solution`](@ref CTModels.OCP.Solution) is the immutable container returned to the user
+once a solver has run. It bundles the **primal trajectories** (state, control, costate), the
+**optimisation variable**, the **objective value**, the **dual variables**, and the
+**solver diagnostics** — all behind a uniform accessor surface.
+
+CTModels does **not** solve OCPs; a `Solution` is assembled from raw numerical arrays by
+[`build_solution`](@ref CTModels.OCP.build_solution), the bridge an NLP backend calls.
+
+```
+model + numerical arrays (T, X, U, v, P, duals, infos)
+                    │
+              build_solution
+                    ▼
+                 Solution ──► state/control/costate/variable/objective/dual/…
+```
+
+## Reading order
+
+| Page | Topic | Key symbols |
+|---|---|---|
+| [Time grids](time_grids.md) | One grid or several | [`UnifiedTimeGridModel`](@ref CTModels.OCP.UnifiedTimeGridModel), [`MultipleTimeGridModel`](@ref CTModels.OCP.MultipleTimeGridModel) |
+| [Trajectories](trajectories.md) | Reading primal data | [`state`](@ref CTModels.OCP.state), [`control`](@ref CTModels.OCP.control), [`costate`](@ref CTModels.OCP.costate) |
+| [Duals & diagnostics](duals.md) | Multipliers and solver status | [`dual`](@ref CTModels.OCP.dual), [`DualModel`](@ref CTModels.OCP.DualModel), [`SolverInfos`](@ref CTModels.OCP.SolverInfos) |
+
+## Minimal end-to-end example
+
+We reuse a minimal model and feed `build_solution` **fabricated** arrays (in practice these
+come from a solver). State, control and costate are sampled on one uniform grid:
+
+```@example sol_index
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+N = 101
+T = collect(range(0.0, 1.0; length=N))
+X = hcat(cos.(T), -sin.(T))      # N×2 : state samples (rows = time)
+U = reshape(-cos.(T), N, 1)      # N×1 : control samples
+P = zeros(N, 2)                  # N×2 : costate samples
+v = Float64[]                    # no optimisation variable
+
+sol = CTModels.build_solution(ocp, T, X, U, v, P;
+    objective=0.5,
+    iterations=10,
+    constraints_violation=1e-9,
+    message="Solve_Succeeded",
+    status=:Solve_Succeeded,
+    successful=true,
+)
+```
+
+The trajectories are returned as **callables** (interpolated from the samples), and the
+diagnostics as scalars:
+
+```@example sol_index
+x = CTModels.state(sol)          # x(t) → state at time t
+(x(0.5),
+ CTModels.objective(sol),
+ CTModels.iterations(sol),
+ CTModels.successful(sol))
+```
+
+## Anatomy of a `Solution`
+
+| Field group | Accessor(s) | Stored as |
+|---|---|---|
+| time grid | [`time_grid`](@ref CTModels.OCP.time_grid) | [`AbstractTimeGridModel`](@ref CTModels.OCP.AbstractTimeGridModel) |
+| state / control / costate | [`state`](@ref CTModels.OCP.state), [`control`](@ref CTModels.OCP.control), [`costate`](@ref CTModels.OCP.costate) | callables `t → …` |
+| variable / objective | [`variable`](@ref CTModels.OCP.variable), [`objective`](@ref CTModels.OCP.objective) | value |
+| duals | [`dual`](@ref CTModels.OCP.dual), [`DualModel`](@ref CTModels.OCP.DualModel) | callables / vectors |
+| diagnostics | [`iterations`](@ref CTModels.OCP.iterations), [`status`](@ref CTModels.OCP.status), [`successful`](@ref CTModels.OCP.successful) | [`SolverInfos`](@ref CTModels.OCP.SolverInfos) |
+
+Each accessor dispatches on a typed field, so reading a solution never inspects raw
+closures. The following pages take each group in turn.
+```

--- a/docs/src/solution/time_grids.md
+++ b/docs/src/solution/time_grids.md
@@ -1,0 +1,91 @@
+# Time grids
+
+```@meta
+CurrentModule = CTModels
+```
+
+A solution stores the discretisation points at which its trajectories were computed. CTModels
+supports either **one shared grid** or **one grid per component**, and chooses the
+representation automatically.
+
+| Type | When | Stores |
+|---|---|---|
+| [`UnifiedTimeGridModel`](@ref CTModels.OCP.UnifiedTimeGridModel) | all components share a grid | a single vector |
+| [`MultipleTimeGridModel`](@ref CTModels.OCP.MultipleTimeGridModel) | state/control/costate/path differ | a named tuple of grids |
+| [`EmptyTimeGridModel`](@ref CTModels.OCP.EmptyTimeGridModel) | no discretisation yet | nothing |
+
+```@example grids
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+nothing # hide
+```
+
+## One shared grid
+
+When the four grids passed to [`build_solution`](@ref CTModels.OCP.build_solution) are
+identical, CTModels collapses them into a [`UnifiedTimeGridModel`](@ref CTModels.OCP.UnifiedTimeGridModel)
+to save memory:
+
+```@example grids
+T = collect(range(0.0, 1.0; length=101))
+X = [1.0 - t/100 for t in 1:101, i in 1:2]
+U = [sin(t/50) for t in 1:101, i in 1:1]
+P = zeros(101, 2)
+
+sol_u = CTModels.build_solution(ocp, T, T, T, T, X, U, Float64[], P;
+    objective=0.5, iterations=10, constraints_violation=1e-6,
+    message="ok", status=:optimal, successful=true)
+
+(CTModels.time_grid_model(sol_u) isa CTModels.UnifiedTimeGridModel,
+ length(CTModels.time_grid(sol_u)))
+```
+
+## One grid per component
+
+Passing different grids for state, control, costate and path yields a
+[`MultipleTimeGridModel`](@ref CTModels.OCP.MultipleTimeGridModel); each component is then
+queried by name through [`time_grid`](@ref CTModels.OCP.time_grid):
+
+```@example grids
+T_state   = collect(range(0.0, 1.0; length=101))
+T_control = collect(range(0.0, 1.0; length=51))
+T_costate = collect(range(0.0, 1.0; length=76))
+T_path    = collect(range(0.0, 1.0; length=61))
+
+X = [1.0 - t/100 for t in 1:101, i in 1:2]
+U = [sin(t/25) for t in 1:51, i in 1:1]
+P = zeros(76, 2)
+
+sol_m = CTModels.build_solution(ocp, T_state, T_control, T_costate, T_path,
+    X, U, Float64[], P;
+    objective=0.5, iterations=10, constraints_violation=1e-6,
+    message="ok", status=:optimal, successful=true)
+
+(CTModels.time_grid_model(sol_m) isa CTModels.MultipleTimeGridModel,
+ length(CTModels.time_grid(sol_m, :state)),
+ length(CTModels.time_grid(sol_m, :control)),
+ length(CTModels.time_grid(sol_m, :costate)))
+```
+
+## Component aliases
+
+`time_grid(sol, :states)`, `time_grid(sol, :duals)`, … accept many synonyms. They are
+normalised to the four canonical grids (`:state`, `:control`, `:costate`, `:path`) by
+[`clean_component_symbols`](@ref CTModels.OCP.clean_component_symbols):
+
+```@example grids
+CTModels.clean_component_symbols((:states, :controls, :costate, :constraint, :duals))
+```
+
+This is why box-constraint duals share the state/control grids, and path-constraint duals the
+`:path` grid — the mapping is centralised in one place rather than scattered across accessors.
+```

--- a/docs/src/solution/trajectories.md
+++ b/docs/src/solution/trajectories.md
@@ -1,0 +1,82 @@
+# Trajectories
+
+```@meta
+CurrentModule = CTModels
+```
+
+The primal part of a solution is read through accessors that return **callables of time**
+(interpolated from the stored samples) for the trajectories, and plain values for the
+variable and the objective.
+
+| Accessor | Returns | Shape |
+|---|---|---|
+| [`state`](@ref CTModels.OCP.state) | `x(t)` | callable → ``\mathbb{R}^n`` |
+| [`control`](@ref CTModels.OCP.control) | `u(t)` | callable → ``\mathbb{R}^m`` |
+| [`costate`](@ref CTModels.OCP.costate) | `p(t)` | callable → ``\mathbb{R}^n`` |
+| [`variable`](@ref CTModels.OCP.variable) | `v` | value |
+| [`objective`](@ref CTModels.OCP.objective) | optimal cost | scalar |
+
+```@example traj
+using CTModels
+
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 1, "v")
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> 0.5u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+
+N = 101
+T = collect(range(0.0, 1.0; length=N))
+X = hcat(cos.(T), -sin.(T))
+U = reshape(-cos.(T), N, 1)
+P = zeros(N, 2)
+v = [2.0]                         # the optimisation variable value
+
+sol = CTModels.build_solution(ocp, T, X, U, v, P;
+    objective=0.5, iterations=10, constraints_violation=1e-9,
+    message="ok", status=:optimal, successful=true)
+nothing # hide
+```
+
+## Reading trajectories
+
+The trajectories are callables, so they can be evaluated at **any** time in the interval,
+not only at grid points — the samples are interpolated:
+
+```@example traj
+x = CTModels.state(sol)
+u = CTModels.control(sol)
+p = CTModels.costate(sol)
+
+(x(0.0), x(0.123), u(0.5), p(1.0))
+```
+
+```@example traj
+(CTModels.variable(sol), CTModels.objective(sol))
+```
+
+## Interpolation of the control
+
+State and costate are interpolated **linearly**. The control may instead be **piecewise
+constant** — typical of direct collocation — selected by the `control_interpolation` keyword
+of [`build_solution`](@ref CTModels.OCP.build_solution) (`:linear` or `:constant`). The choice
+is recorded and read back with
+[`control_interpolation`](@ref CTModels.OCP.control_interpolation):
+
+```@example traj
+sol_const = CTModels.build_solution(ocp, T, X, U, v, P;
+    objective=0.5, iterations=10, constraints_violation=1e-9,
+    message="ok", status=:optimal, successful=true,
+    control_interpolation=:constant)
+
+(CTModels.control_interpolation(sol), CTModels.control_interpolation(sol_const))
+```
+
+Because the interpolation kind is a stored field — not baked into an opaque closure —
+downstream code (plotting, serialization) can branch on it explicitly. The
+[Duals & diagnostics](duals.md) page covers the remaining accessors.
+```

--- a/ext/CTModelsJLD.jl
+++ b/ext/CTModelsJLD.jl
@@ -1,3 +1,10 @@
+"""
+Weak-dependency extension of [`CTModels`](@ref) providing JLD2-based serialization.
+
+Loaded automatically when both `CTModels` and `JLD2` are available in the session.
+Adds methods for [`CTModels.export_ocp_solution`](@ref) and
+[`CTModels.import_ocp_solution`](@ref) dispatching on [`CTModels.JLD2Tag`](@ref).
+"""
 module CTModelsJLD
 
 using CTModels

--- a/ext/CTModelsJSON.jl
+++ b/ext/CTModelsJSON.jl
@@ -1,3 +1,10 @@
+"""
+Weak-dependency extension of [`CTModels`](@ref) providing JSON3-based serialization.
+
+Loaded automatically when both `CTModels` and `JSON3` are available in the session.
+Adds methods for [`CTModels.export_ocp_solution`](@ref) and
+[`CTModels.import_ocp_solution`](@ref) dispatching on [`CTModels.JSON3Tag`](@ref).
+"""
 module CTModelsJSON
 
 using CTModels
@@ -11,8 +18,10 @@ import CTModels.OCP: __control_interpolation
 # Private helpers for JSON matrix conversion
 # ============================================================================
 
-# Liste des champs matriciels à convertir
+"Solution fields that are always serialized as `Matrix{Float64}` and must be converted to `Vector{Vector}` for JSON3."
 const _MATRIX_FIELDS = ["state", "control", "costate"]
+
+"Solution fields that may be present (non-empty duals) and require the same `Matrix → Vector{Vector}` conversion."
 const _OPTIONAL_MATRIX_FIELDS = [
     "path_constraints_dual",
     "state_constraints_lb_dual",

--- a/ext/CTModelsPlots.jl
+++ b/ext/CTModelsPlots.jl
@@ -1,3 +1,10 @@
+"""
+Weak-dependency extension of [`CTModels`](@ref) providing Plots.jl recipes.
+
+Loaded automatically when both `CTModels` and `Plots` are available in the session.
+Extends `Plots.plot` and `Plots.plot!` to accept a `CTModels.Solution`, rendering
+state, control, costate, and dual trajectories in a configurable layout.
+"""
 module CTModelsPlots
 
 #

--- a/src/CTModels.jl
+++ b/src/CTModels.jl
@@ -1,67 +1,32 @@
 """
     CTModels
 
-Control Toolbox Models (CTModels) - A Julia package for optimal control problems.
+Mathematical model layer for optimal control problems in the
+[control-toolbox](https://github.com/control-toolbox) ecosystem.
 
-This module provides a comprehensive framework for defining, building, and solving
-optimal control problems with a modular architecture that separates concerns and
-facilitates extensibility.
+Provides types and building blocks for states, controls, variables, time grids,
+constraints, and cost functionals; structures for representing numerical solutions;
+initial-guess management; and optional extensions for serialization and plotting.
 
-# Architecture Overview
+# Modules
 
-CTModels is organized into specialized modules, each with clear responsibilities:
+| Module | Responsibility |
+|--------|---------------|
+| [`CTModels.OCP`](@ref) | Types and builders for optimal control problems and solutions |
+| [`CTModels.Utils`](@ref) | Interpolation, matrix utilities, `@ensure` validation macro |
+| [`CTModels.Display`](@ref) | `Base.show` extensions for models and solutions |
+| [`CTModels.Serialization`](@ref) | `export_ocp_solution` / `import_ocp_solution` (JLD2, JSON) |
+| [`CTModels.Init`](@ref) | Initial guess construction and validation |
 
-## Core Modules
+# Extensions
 
-- **OCP**: Optimal Control Problem core
-  - Types: `Model`, `PreModel`, `Solution`, `AbstractModel`, `AbstractSolution`
-  - Components: state, control, dynamics, objective, constraints
-  - Builders: model construction and solution building
-  - Type aliases: `Dimension`, `ctNumber`, `Time`, `Times`, `TimesDisc`, `ConstraintsDictType`
+| Extension | Trigger package | Adds |
+|-----------|----------------|------|
+| `CTModelsPlots` | `Plots.jl` | `Plots.plot(sol)` and `Plots.plot!(sol)` |
+| `CTModelsJSON` | `JSON3.jl` | JSON serialization |
+| `CTModelsJLD` | `JLD2.jl` | JLD2 serialization |
 
-- **Utils**: General utilities
-  - Interpolation: `ctinterpolate`
-  - Matrix operations: `matrix2vec`
-  - Macros: `@ensure` for validation
-
-- **Display**: Formatting and visualization
-  - Text display via `Base.show` extensions
-  - Plotting stubs via `RecipesBase.plot`
-
-- **Serialization**: Import/export functionality
-  - `export_ocp_solution`, `import_ocp_solution`
-  - Format tags: `JLD2Tag`, `JSON3Tag`
-
-- **InitialGuess**: Initial guess management
-  - `initial_guess`, `build_initial_guess`, `validate_initial_guess`
-  - Types: `InitialGuess`, `PreInitialGuess`
-
-## Supporting Modules
-
-- **Options**: Configuration and options management
-- **Strategies**: Strategy patterns for optimization
-- **Orchestration**: High-level orchestration and coordination
-- **Optimization**: General optimization types and builders
-- **Modelers**: Modeler implementations (ADNLPModeler, ExaModeler)
-- **DOCP**: Discretized Optimal Control Problem types
-
-# Loading Order
-
-Modules are loaded in dependency order to ensure all types and functions are available
-when needed:
-
-1. **Foundational types** → **Utils** → **OCP** → **Display/Serialization/InitialGuess**
-2. **Supporting modules** → **Optimization** → **Modelers** → **DOCP**
-
-# Public API
-
-All exported functions and types are accessible via `CTModels.function_name()`.
-The modular architecture ensures that:
-
-- Types are defined where they belong
-- Dependencies are explicit and minimal
-- Extensions can target specific modules
-- The public API remains stable and clean
+All public symbols are accessed as `CTModels.symbol` (no top-level exports).
 """
 module CTModels
 

--- a/src/Display/Display.jl
+++ b/src/Display/Display.jl
@@ -21,7 +21,6 @@ The following are internal utilities (accessible via `Display.function_name`):
 - `__print_abstract_definition`: Print abstract OCP definition
 - `__print_mathematical_definition`: Print mathematical OCP formulation
 
-See also: `CTModels`
 """
 module Display
 

--- a/src/Init/Init.jl
+++ b/src/Init/Init.jl
@@ -19,7 +19,6 @@ The following functions are exported and accessible as `CTModels.function_name()
 - `InitialGuess`: Validated initial guess with callable trajectories
 - `PreInitialGuess`: Pre-initialization container for raw data
 
-See also: `CTModels`
 """
 module Init
 

--- a/src/Init/types.jl
+++ b/src/Init/types.jl
@@ -9,7 +9,7 @@ Abstract base type for initial guesses used in optimal control problem solvers.
 Subtypes provide initial trajectories for state, control, and optimisation variables
 to warm-start numerical solvers.
 
-See also: `InitialGuess`.
+See also: [`CTModels.Init.InitialGuess`](@ref), [`CTModels.Init.PreInitialGuess`](@ref).
 """
 abstract type AbstractInitialGuess end
 
@@ -35,6 +35,8 @@ julia> u_guess = t -> [0.5]
 julia> v_guess = [1.0, 2.0]
 julia> ig = CTModels.InitialGuess(x_guess, u_guess, v_guess)
 ```
+
+See also: [`CTModels.Init.AbstractInitialGuess`](@ref), [`CTModels.Init.PreInitialGuess`](@ref).
 """
 struct InitialGuess{X<:Function,U<:Function,V} <: AbstractInitialGuess
     state::X
@@ -49,9 +51,9 @@ Abstract base type for pre-initialisation data used before constructing a full
 initial guess.
 
 Subtypes store raw or partial information that will be processed into an
-`InitialGuess`.
+[`CTModels.Init.InitialGuess`](@ref).
 
-See also: `PreInitialGuess`.
+See also: [`CTModels.Init.PreInitialGuess`](@ref).
 """
 abstract type AbstractPreInitialGuess end
 
@@ -74,6 +76,8 @@ julia> using CTModels
 
 julia> pre = CTModels.PreInitialGuess([1.0 2.0; 3.0 4.0], [0.5, 0.6], [1.0])
 ```
+
+See also: [`CTModels.Init.AbstractPreInitialGuess`](@ref), [`CTModels.Init.InitialGuess`](@ref).
 """
 struct PreInitialGuess{SX,SU,SV} <: AbstractPreInitialGuess
     state::SX

--- a/src/OCP/Building/discretization_utils.jl
+++ b/src/OCP/Building/discretization_utils.jl
@@ -34,7 +34,7 @@ result = _discretize_function(f_vec, [0.0, 0.5, 1.0])
 # result = [0.0 0.0; 0.5 1.0; 1.0 2.0]
 ```
 
-See also: `_discretize_dual`
+See also: [`CTModels.OCP._discretize_dual`](@ref).
 """
 function _discretize_function(f::Function, T::AbstractVector, dim::Int=-1)::Matrix{Float64}
     n = length(T)
@@ -62,7 +62,7 @@ $(TYPEDSIGNATURES)
 
 Discretize a function on a `TimeGridModel` by extracting the underlying time grid.
 
-See also: `_discretize_function`
+See also: [`CTModels.OCP._discretize_function`](@ref).
 """
 function _discretize_function(f::Function, T::TimeGridModel, dim::Int=-1)::Matrix{Float64}
     return _discretize_function(f, T.value, dim)
@@ -82,7 +82,7 @@ Discretize a dual function, returning `nothing` if the input is `nothing`.
 - `Matrix{Float64}` if `dual_func` is a function.
 - `nothing` if `dual_func` is `nothing`.
 
-See also: `_discretize_function`
+See also: [`CTModels.OCP._discretize_function`](@ref).
 """
 function _discretize_dual(dual_func::Union{Function,Nothing}, T, dim::Int=-1)
     return isnothing(dual_func) ? nothing : _discretize_function(dual_func, T, dim)

--- a/src/OCP/Building/model.jl
+++ b/src/OCP/Building/model.jl
@@ -550,7 +550,8 @@ objective!(pre_ocp, :mayer, (x0, xf) -> xf[1]^2)
 ocp = build_model(pre_ocp)
 ```
 
-See also: `build`, `PreModel`, `Model`, `time_dependence!`
+See also: [`CTModels.OCP.build`](@ref), [`CTModels.OCP.PreModel`](@ref),
+[`CTModels.OCP.Model`](@ref), [`CTModels.OCP.time_dependence!`](@ref).
 """
 function build_model(pre_ocp::PreModel; build_examodel=nothing)::Model
     return build(pre_ocp; build_examodel=build_examodel)

--- a/src/OCP/Building/solution.jl
+++ b/src/OCP/Building/solution.jl
@@ -183,8 +183,9 @@ reducing memory overhead. This is detected automatically.
 A legacy signature `build_solution(ocp, T, X, U, v, P; ...)` exists for single-grid solutions. 
 It internally calls this multi-grid version with `T_state = T_control = T_costate = T_path = T`.
 
-See also: `Solution`, `UnifiedTimeGridModel`, `MultipleTimeGridModel`, 
-`time_grid`, `state`, `control`, `costate`
+See also: [`CTModels.OCP.Solution`](@ref), [`CTModels.OCP.UnifiedTimeGridModel`](@ref),
+[`CTModels.OCP.MultipleTimeGridModel`](@ref), [`CTModels.OCP.time_grid`](@ref),
+[`CTModels.OCP.state`](@ref), [`CTModels.OCP.control`](@ref), [`CTModels.OCP.costate`](@ref).
 """
 function build_solution(
     ocp::Model,
@@ -608,9 +609,9 @@ $(TYPEDSIGNATURES)
 
 Return the state as a function of time.
 
-```@example
-julia> x  = state(sol)
-julia> t0 = time_grid(sol)[1]
+```julia-repl
+julia> x  = CTModels.state(sol)
+julia> t0 = CTModels.time_grid(sol)[1]
 julia> x0 = x(t0) # state at the initial time
 ```
 """
@@ -678,9 +679,9 @@ $(TYPEDSIGNATURES)
 
 Return the control as a function of time.
 
-```@example
-julia> u  = control(sol)
-julia> t0 = time_grid(sol)[1]
+```julia-repl
+julia> u  = CTModels.control(sol)
+julia> t0 = CTModels.time_grid(sol)[1]
 julia> u0 = u(t0) # control at the initial time
 ```
 """
@@ -802,8 +803,8 @@ $(TYPEDSIGNATURES)
 
 Return the variable or `nothing`.
 
-```@example
-julia> v  = variable(sol)
+```julia-repl
+julia> v = CTModels.variable(sol)
 ```
 """
 function variable(
@@ -828,9 +829,9 @@ $(TYPEDSIGNATURES)
 
 Return the costate as a function of time.
 
-```@example
-julia> p  = costate(sol)
-julia> t0 = time_grid(sol)[1]
+```julia-repl
+julia> p  = CTModels.costate(sol)
+julia> t0 = CTModels.time_grid(sol)[1]
 julia> p0 = p(t0) # costate at the initial time
 ```
 """

--- a/src/OCP/Building/solution.jl
+++ b/src/OCP/Building/solution.jl
@@ -1637,7 +1637,7 @@ This format is used when `build_solution` is called with identical grids for all
 or when using the legacy single-grid signature. It ensures backward compatibility with files 
 created before the multi-grid feature was introduced.
 
-See also: [`_serialize_solution(::MultipleTimeGridModel, ...)`](@ref)
+See also: [`CTModels.OCP._serialize_solution`](@ref)
 """
 function _serialize_solution(::UnifiedTimeGridModel, sol::Solution, dim_x::Int, dim_u::Int)
     # Legacy format: single time grid
@@ -1697,7 +1697,7 @@ components. It allows numerical schemes to use optimal discretizations for each 
 The reconstruction function `_reconstruct_solution_from_data` detects this format by checking 
 for the presence of `"time_grid_state"` key and handles it appropriately.
 
-See also: [`_serialize_solution(::UnifiedTimeGridModel, ...)`](@ref), [`build_solution`](@ref)
+See also: [`CTModels.OCP._serialize_solution`](@ref), [`CTModels.OCP.build_solution`](@ref)
 """
 function _serialize_solution(::MultipleTimeGridModel, sol::Solution, dim_x::Int, dim_u::Int)
     # Multiple time grids format

--- a/src/OCP/Components/objective.jl
+++ b/src/OCP/Components/objective.jl
@@ -238,7 +238,7 @@ Alias for `has_mayer_cost`. Check if the objective has a Mayer (terminal) cost d
 julia> is_mayer_cost_defined(obj)  # equivalent to has_mayer_cost(obj)
 ```
 
-See also: `has_mayer_cost`, `is_lagrange_cost_defined`.
+See also: [`CTModels.OCP.has_mayer_cost`](@ref), [`CTModels.OCP.is_lagrange_cost_defined`](@ref).
 """
 const is_mayer_cost_defined = has_mayer_cost
 
@@ -252,6 +252,6 @@ Alias for `has_lagrange_cost`. Check if the objective has a Lagrange (integral) 
 julia> is_lagrange_cost_defined(obj)  # equivalent to has_lagrange_cost(obj)
 ```
 
-See also: `has_lagrange_cost`, `is_mayer_cost_defined`.
+See also: [`CTModels.OCP.has_lagrange_cost`](@ref), [`CTModels.OCP.is_mayer_cost_defined`](@ref).
 """
 const is_lagrange_cost_defined = has_lagrange_cost

--- a/src/OCP/Components/state.jl
+++ b/src/OCP/Components/state.jl
@@ -9,48 +9,32 @@ Define the state dimension and possibly the names of each component.
 
 # Examples
 
-```@example
-julia> state!(ocp, 1)
-julia> state_dimension(ocp)
-1
-julia> state_components(ocp)
-["x"]
+Each call below starts from a fresh `PreModel` (`state!` may be used only once per
+problem). The forms illustrate the default name, a custom name, and explicit component
+names:
 
-julia> state!(ocp, 1, "y")
-julia> state_dimension(ocp)
-1
-julia> state_components(ocp)
-["y"]
+```julia-repl
+julia> using CTModels
 
-julia> state!(ocp, 2)
-julia> state_dimension(ocp)
-2
-julia> state_components(ocp)
-["x₁", "x₂"]
+julia> ocp = CTModels.PreModel(); CTModels.state!(ocp, 1);
 
-julia> state!(ocp, 2, :y)
-julia> state_dimension(ocp)
-2
-julia> state_components(ocp)
-["y₁", "y₂"]
+julia> CTModels.state_dimension(ocp), CTModels.state_components(ocp)
+(1, ["x"])
 
-julia> state!(ocp, 2, "y")
-julia> state_dimension(ocp)
-2
-julia> state_components(ocp)
-["y₁", "y₂"]
+julia> ocp = CTModels.PreModel(); CTModels.state!(ocp, 2);
 
-julia> state!(ocp, 2, "y", ["u", "v"])
-julia> state_dimension(ocp)
-2
-julia> state_components(ocp)
-["u", "v"]
+julia> CTModels.state_dimension(ocp), CTModels.state_components(ocp)
+(2, ["x₁", "x₂"])
 
-julia> state!(ocp, 2, "y", [:u, :v])
-julia> state_dimension(ocp)
-2
-julia> state_components(ocp)
-["u", "v"]
+julia> ocp = CTModels.PreModel(); CTModels.state!(ocp, 2, "y");
+
+julia> CTModels.state_dimension(ocp), CTModels.state_components(ocp)
+(2, ["y₁", "y₂"])
+
+julia> ocp = CTModels.PreModel(); CTModels.state!(ocp, 2, "y", ["u", "v"]);
+
+julia> CTModels.state_dimension(ocp), CTModels.state_components(ocp)
+(2, ["u", "v"])
 ```
 
 # Throws

--- a/src/OCP/Components/times.jl
+++ b/src/OCP/Components/times.jl
@@ -11,21 +11,27 @@ When a time is free, then, one must provide the corresponding index of the ocp v
 
 # Examples
 
-```@example
-julia> time!(ocp, t0=0,   tf=1  ) # Fixed t0 and fixed tf
-julia> time!(ocp, t0=0,   indf=2) # Fixed t0 and free  tf
-julia> time!(ocp, ind0=2, tf=1  ) # Free  t0 and fixed tf
-julia> time!(ocp, ind0=2, indf=3) # Free  t0 and free  tf
+`time!` may be used only once per problem; each form below applies to a fresh `ocp`:
+
+```julia-repl
+julia> using CTModels
+
+julia> CTModels.time!(ocp; t0=0, tf=1)     # Fixed t0 and fixed tf
+
+julia> CTModels.time!(ocp; t0=0, indf=2)   # Fixed t0 and free  tf
+
+julia> CTModels.time!(ocp; ind0=2, tf=1)   # Free  t0 and fixed tf
+
+julia> CTModels.time!(ocp; ind0=2, indf=3) # Free  t0 and free  tf
 ```
 
-When you plot a solution of an optimal control problem, the name of the time variable appears.
-By default, the name is "t".
-Consider you want to set the name of the time variable to "s".
+When a solution is plotted, the name of the time variable appears (`"t"` by default).
+To name the time variable `"s"`:
 
-```@example
-julia> time!(ocp, t0=0, tf=1, time_name="s") # time_name is a String
-# or
-julia> time!(ocp, t0=0, tf=1, time_name=:s ) # time_name is a Symbol  
+```julia-repl
+julia> CTModels.time!(ocp; t0=0, tf=1, time_name="s") # time_name as a String
+
+julia> CTModels.time!(ocp; t0=0, tf=1, time_name=:s)  # time_name as a Symbol
 ```
 
 # Throws
@@ -406,7 +412,7 @@ Alias for `has_fixed_initial_time`. Check if the initial time is fixed.
 julia> is_initial_time_fixed(times)  # equivalent to has_fixed_initial_time(times)
 ```
 
-See also: `has_fixed_initial_time`, `is_initial_time_free`.
+See also: [`CTModels.OCP.has_fixed_initial_time`](@ref), [`CTModels.OCP.is_initial_time_free`](@ref).
 """
 const is_initial_time_fixed = has_fixed_initial_time
 
@@ -420,7 +426,7 @@ Alias for `has_free_initial_time`. Check if the initial time is free.
 julia> is_initial_time_free(times)  # equivalent to has_free_initial_time(times)
 ```
 
-See also: `has_free_initial_time`, `is_initial_time_fixed`.
+See also: [`CTModels.OCP.has_free_initial_time`](@ref), [`CTModels.OCP.is_initial_time_fixed`](@ref).
 """
 const is_initial_time_free = has_free_initial_time
 
@@ -434,7 +440,7 @@ Alias for `has_fixed_final_time`. Check if the final time is fixed.
 julia> is_final_time_fixed(times)  # equivalent to has_fixed_final_time(times)
 ```
 
-See also: `has_fixed_final_time`, `is_final_time_free`.
+See also: [`CTModels.OCP.has_fixed_final_time`](@ref), [`CTModels.OCP.is_final_time_free`](@ref).
 """
 const is_final_time_fixed = has_fixed_final_time
 
@@ -448,6 +454,6 @@ Alias for `has_free_final_time`. Check if the final time is free.
 julia> is_final_time_free(times)  # equivalent to has_free_final_time(times)
 ```
 
-See also: `has_free_final_time`, `is_final_time_fixed`.
+See also: [`CTModels.OCP.has_free_final_time`](@ref), [`CTModels.OCP.is_final_time_fixed`](@ref).
 """
 const is_final_time_free = has_free_final_time

--- a/src/OCP/OCP.jl
+++ b/src/OCP/OCP.jl
@@ -24,7 +24,6 @@ The main exported types and functions are accessible via `CTModels.function_name
 - Component builders: `state!`, `control!`, `variable!`, etc.
 - Model builders: `build_model`, `build_solution`
 
-See also: `CTModels`
 """
 module OCP
 

--- a/src/OCP/Types/components.jl
+++ b/src/OCP/Types/components.jl
@@ -10,7 +10,7 @@ Abstract base type representing time dependence of an optimal control problem.
 Used as a type parameter to distinguish between autonomous and non-autonomous
 systems at the type level, enabling dispatch and compile-time optimisations.
 
-See also: `Autonomous`, `NonAutonomous`.
+See also: [`CTModels.OCP.Autonomous`](@ref), [`CTModels.OCP.NonAutonomous`](@ref).
 """
 abstract type TimeDependence end
 
@@ -23,7 +23,7 @@ problem do not explicitly depend on time.
 For autonomous systems, the dynamics have the form `ẋ = f(x, u)` rather than
 `ẋ = f(t, x, u)`.
 
-See also: `TimeDependence`, `NonAutonomous`.
+See also: [`CTModels.OCP.TimeDependence`](@ref), [`CTModels.OCP.NonAutonomous`](@ref).
 """
 abstract type Autonomous<:TimeDependence end
 
@@ -35,7 +35,7 @@ problem explicitly depend on time.
 
 For non-autonomous systems, the dynamics have the form `ẋ = f(t, x, u)`.
 
-See also: `TimeDependence`, `Autonomous`.
+See also: [`CTModels.OCP.TimeDependence`](@ref), [`CTModels.OCP.Autonomous`](@ref).
 """
 abstract type NonAutonomous<:TimeDependence end
 
@@ -48,7 +48,7 @@ Abstract base type for state variable models in optimal control problems.
 Subtypes describe the state space structure including dimension, naming, and
 optionally the state trajectory itself.
 
-See also: `StateModel`, `StateModelSolution`.
+See also: [`CTModels.OCP.StateModel`](@ref), [`CTModels.OCP.StateModelSolution`](@ref).
 """
 abstract type AbstractStateModel end
 
@@ -70,6 +70,8 @@ julia> using CTModels
 
 julia> sm = CTModels.StateModel("x", ["position", "velocity"])
 ```
+
+See also: [`CTModels.OCP.AbstractStateModel`](@ref), [`CTModels.OCP.StateModelSolution`](@ref).
 """
 struct StateModel <: AbstractStateModel
     name::String
@@ -99,6 +101,8 @@ julia> sms.value(0.0)
  1.0
  0.0
 ```
+
+See also: [`CTModels.OCP.AbstractStateModel`](@ref), [`CTModels.OCP.StateModel`](@ref).
 """
 struct StateModelSolution{TS<:Function} <: AbstractStateModel
     name::String
@@ -115,7 +119,8 @@ Abstract base type for control variable models in optimal control problems.
 Subtypes describe the control space structure including dimension, naming, and
 optionally the control trajectory itself.
 
-See also: `ControlModel`, `ControlModelSolution`.
+See also: [`CTModels.OCP.ControlModel`](@ref), [`CTModels.OCP.ControlModelSolution`](@ref),
+[`CTModels.OCP.EmptyControlModel`](@ref).
 """
 abstract type AbstractControlModel end
 
@@ -137,6 +142,8 @@ julia> using CTModels
 
 julia> cm = CTModels.ControlModel("u", ["thrust", "steering"])
 ```
+
+See also: [`CTModels.OCP.AbstractControlModel`](@ref), [`CTModels.OCP.ControlModelSolution`](@ref).
 """
 struct ControlModel <: AbstractControlModel
     name::String
@@ -165,6 +172,8 @@ julia> cms.value(π/2)
 1-element Vector{Float64}:
  1.0
 ```
+
+See also: [`CTModels.OCP.AbstractControlModel`](@ref), [`CTModels.OCP.ControlModel`](@ref).
 """
 struct ControlModelSolution{TS<:Function} <: AbstractControlModel
     name::String
@@ -211,7 +220,8 @@ Abstract base type for optimisation variable models in optimal control problems.
 Optimisation variables are decision variables that do not depend on time, such as
 free final time or unknown parameters.
 
-See also: `VariableModel`, `EmptyVariableModel`, `VariableModelSolution`.
+See also: [`CTModels.OCP.VariableModel`](@ref), [`CTModels.OCP.EmptyVariableModel`](@ref),
+[`CTModels.OCP.VariableModelSolution`](@ref).
 """
 abstract type AbstractVariableModel end
 
@@ -233,6 +243,8 @@ julia> using CTModels
 
 julia> vm = CTModels.VariableModel("v", ["final_time", "parameter"])
 ```
+
+See also: [`CTModels.OCP.AbstractVariableModel`](@ref), [`CTModels.OCP.VariableModelSolution`](@ref).
 """
 struct VariableModel <: AbstractVariableModel
     name::String
@@ -254,6 +266,8 @@ julia> using CTModels
 
 julia> evm = CTModels.EmptyVariableModel()
 ```
+
+See also: [`CTModels.OCP.AbstractVariableModel`](@ref), [`CTModels.OCP.VariableModel`](@ref).
 """
 struct EmptyVariableModel <: AbstractVariableModel end
 
@@ -277,6 +291,9 @@ julia> vms = CTModels.VariableModelSolution("v", ["tf"], 2.5)
 julia> vms.value
 2.5
 ```
+
+See also: [`CTModels.OCP.AbstractVariableModel`](@ref), [`CTModels.OCP.VariableModel`](@ref),
+[`CTModels.OCP.EmptyVariableModel`](@ref).
 """
 struct VariableModelSolution{TS<:Union{ctNumber,ctVector}} <: AbstractVariableModel
     name::String
@@ -293,7 +310,7 @@ Abstract base type for time boundary models (initial or final time).
 Subtypes represent either fixed or free time boundaries in an optimal control
 problem.
 
-See also: `FixedTimeModel`, `FreeTimeModel`.
+See also: [`CTModels.OCP.FixedTimeModel`](@ref), [`CTModels.OCP.FreeTimeModel`](@ref).
 """
 abstract type AbstractTimeModel end
 
@@ -354,7 +371,7 @@ $(TYPEDEF)
 
 Abstract base type for combined initial and final time models.
 
-See also: `TimesModel`.
+See also: [`CTModels.OCP.TimesModel`](@ref).
 """
 abstract type AbstractTimesModel end
 
@@ -394,7 +411,8 @@ Abstract base type for objective function models in optimal control problems.
 Subtypes represent different forms of the cost functional: Mayer (terminal cost),
 Lagrange (integral cost), or Bolza (both).
 
-See also: `MayerObjectiveModel`, `LagrangeObjectiveModel`, `BolzaObjectiveModel`.
+See also: [`CTModels.OCP.MayerObjectiveModel`](@ref), [`CTModels.OCP.LagrangeObjectiveModel`](@ref),
+[`CTModels.OCP.BolzaObjectiveModel`](@ref).
 """
 abstract type AbstractObjectiveModel end
 
@@ -485,7 +503,7 @@ Abstract base type for constraint models in optimal control problems.
 Subtypes store all constraint information including path constraints, boundary
 constraints, and box constraints on state, control, and variables.
 
-See also: `ConstraintsModel`.
+See also: [`CTModels.OCP.ConstraintsModel`](@ref).
 """
 abstract type AbstractConstraintsModel end
 

--- a/src/OCP/Types/model.jl
+++ b/src/OCP/Types/model.jl
@@ -9,7 +9,7 @@ Abstract base type for optimal control problem models.
 Subtypes represent either a fully built immutable model ([`Model`](@ref CTModels.OCP.Model)) or a
 mutable model under construction (`PreModel`).
 
-See also: [`Model`](@ref CTModels.OCP.Model), `PreModel`.
+See also: [`CTModels.OCP.Model`](@ref), [`CTModels.OCP.PreModel`](@ref).
 """
 abstract type AbstractModel end
 
@@ -241,7 +241,9 @@ $(TYPEDSIGNATURES)
 
 Return the state dimension of the `PreModel`.
 
-Throws `Exceptions.PreconditionError` if state has not been set.
+# Throws
+
+- `Exceptions.PreconditionError`: if the state has not been set yet.
 """
 function state_dimension(ocp::PreModel)::Dimension
     @ensure(

--- a/src/OCP/Types/solution.jl
+++ b/src/OCP/Types/solution.jl
@@ -9,7 +9,8 @@ Abstract base type for time grid models used in optimal control solutions.
 
 Subtypes store the discretised time points at which the solution is evaluated.
 
-See also: `TimeGridModel`, `EmptyTimeGridModel`.
+See also: [`CTModels.OCP.UnifiedTimeGridModel`](@ref), [`CTModels.OCP.MultipleTimeGridModel`](@ref),
+[`CTModels.OCP.EmptyTimeGridModel`](@ref).
 """
 abstract type AbstractTimeGridModel end
 
@@ -231,7 +232,7 @@ Abstract base type for solver information associated with an optimal control sol
 
 Subtypes store metadata about the numerical solution process.
 
-See also: `SolverInfos`.
+See also: [`CTModels.OCP.SolverInfos`](@ref).
 """
 abstract type AbstractSolverInfos end
 
@@ -277,7 +278,7 @@ Abstract base type for dual variable models in optimal control solutions.
 
 Subtypes store Lagrange multipliers (dual variables) associated with constraints.
 
-See also: `DualModel`.
+See also: [`CTModels.OCP.DualModel`](@ref).
 """
 abstract type AbstractDualModel end
 
@@ -337,7 +338,7 @@ Abstract base type for optimal control problem solutions.
 Subtypes store the complete solution including primal trajectories, dual variables,
 and solver information.
 
-See also: `Solution`.
+See also: [`CTModels.OCP.Solution`](@ref).
 """
 abstract type AbstractSolution end
 

--- a/src/OCP/Types/solution.jl
+++ b/src/OCP/Types/solution.jl
@@ -108,7 +108,14 @@ function MultipleTimeGridModel(;
     return MultipleTimeGridModel((state=state, control=control, costate=costate, path=path))
 end
 
-# Legacy alias for backward compatibility
+"""
+Legacy type alias for [`CTModels.OCP.UnifiedTimeGridModel`](@ref).
+
+Kept for backward compatibility with code written before the multi-grid feature.
+Prefer [`CTModels.OCP.UnifiedTimeGridModel`](@ref) for new code.
+
+See also: [`CTModels.OCP.UnifiedTimeGridModel`](@ref), [`CTModels.OCP.MultipleTimeGridModel`](@ref).
+"""
 const TimeGridModel = UnifiedTimeGridModel
 
 """

--- a/src/OCP/Validation/name_validation.jl
+++ b/src/OCP/Validation/name_validation.jl
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 
 """
-    __collect_used_names(ocp::PreModel)::Vector{String}
+$(TYPEDSIGNATURES)
 
 Collect all names already used in the PreModel across all components.
 
@@ -27,7 +27,7 @@ julia> __collect_used_names(ocp)
  "u"
 ```
 
-See also: `__has_name_conflict`, `__validate_name_uniqueness`
+See also: [`CTModels.OCP.__has_name_conflict`](@ref), [`CTModels.OCP.__validate_name_uniqueness`](@ref).
 """
 function __collect_used_names(ocp::PreModel)::Vector{String}
     names = String[]
@@ -61,7 +61,7 @@ function __collect_used_names(ocp::PreModel)::Vector{String}
 end
 
 """
-    __has_name_conflict(ocp::PreModel, new_name::String, exclude_component::Symbol=:none)::Bool
+$(TYPEDSIGNATURES)
 
 Check if a name conflicts with existing names in the PreModel.
 
@@ -90,7 +90,7 @@ julia> __has_name_conflict(ocp, "y", :none)
 false
 ```
 
-See also: `__collect_used_names`, `__validate_name_uniqueness`
+See also: [`CTModels.OCP.__collect_used_names`](@ref), [`CTModels.OCP.__validate_name_uniqueness`](@ref).
 """
 function __has_name_conflict(
     ocp::PreModel, new_name::String, exclude_component::Symbol=:none
@@ -116,8 +116,7 @@ function __has_name_conflict(
 end
 
 """
-    __validate_name_uniqueness(ocp::PreModel, name::String, components::Vector{String}, 
-                               component_type::Symbol)
+$(TYPEDSIGNATURES)
 
 Validate that a name and its components don't conflict with existing names.
 
@@ -147,7 +146,7 @@ julia> state!(ocp, 2, "x", ["x₁", "x₂"])
 julia> __validate_name_uniqueness(ocp, "x", ["u"], :control)  # Would throw if "x" conflicts
 ```
 
-See also: `__has_name_conflict`, `__collect_used_names`
+See also: [`CTModels.OCP.__has_name_conflict`](@ref), [`CTModels.OCP.__collect_used_names`](@ref).
 """
 function __validate_name_uniqueness(
     ocp::PreModel, name::String, components::Vector{String}, component_type::Symbol

--- a/src/OCP/aliases.jl
+++ b/src/OCP/aliases.jl
@@ -1,11 +1,10 @@
 # Type aliases for CTModels
 
 """
-Type alias for a dimension. This is used to define the dimension of the state space, 
-the costate space, the control space, etc.
+Type alias for a dimension, used for the state, costate, control and variable spaces.
 
-```@example
-julia> const Dimension = Integer
+```julia
+const Dimension = Int
 ```
 """
 const Dimension = Int
@@ -13,64 +12,67 @@ const Dimension = Int
 """
 Type alias for a real number.
 
-```@example
-julia> const ctNumber = Real
+```julia
+const ctNumber = Real
 ```
 """
 const ctNumber = Real
 
 """
-Type alias for a time.
+Type alias for a (continuous) time.
 
-```@example
-julia> const Time = ctNumber
+```julia
+const Time = ctNumber
 ```
 
-See also: `ctNumber`, [`Times`](@ref CTModels.OCP.Times), `TimesDisc`.
+See also: [`CTModels.OCP.ctNumber`](@ref), [`CTModels.OCP.Times`](@ref), [`CTModels.OCP.TimesDisc`](@ref).
 """
 const Time = ctNumber
 
 """
 Type alias for a vector of real numbers.
 
-```@example
-julia> const ctVector = AbstractVector{<:ctNumber}
+```julia
+const ctVector = AbstractVector{<:ctNumber}
 ```
 
-See also: `ctNumber`.
+See also: [`CTModels.OCP.ctNumber`](@ref).
 """
 const ctVector = AbstractVector{<:ctNumber}
 
 """
 Type alias for a vector of times.
 
-```@example
-julia> const Times = AbstractVector{<:Time}
+```julia
+const Times = AbstractVector{<:Time}
 ```
 
-See also: `Time`, `TimesDisc`.
+See also: [`CTModels.OCP.Time`](@ref), [`CTModels.OCP.TimesDisc`](@ref).
 """
 const Times = AbstractVector{<:Time}
 
 """
-Type alias for a grid of times. This is used to define a discretization of time interval given to solvers.
+Type alias for a grid of times, used to discretize the time interval given to solvers.
 
-```@example
-julia> const TimesDisc = Union{Times, StepRangeLen}
+```julia
+const TimesDisc = Union{Times,StepRangeLen}
 ```
 
-See also: `Time`, [`Times`](@ref CTModels.OCP.Times).
+See also: [`CTModels.OCP.Time`](@ref), [`CTModels.OCP.Times`](@ref).
 """
 const TimesDisc = Union{Times,StepRangeLen}
 
 """
-Type alias for a dictionary of constraints. This is used to store constraints before building the model.
+Type alias for a dictionary of constraints, used to store constraints before building the model.
 
-```@example
-julia> const TimesDisc = Union{Times, StepRangeLen}
+```julia
+const ConstraintsDictType = OrderedDict{
+    Symbol,Tuple{Symbol,Union{Function,OrdinalRange{<:Int}},ctVector,ctVector}
+}
 ```
 
-See also: `ConstraintsModel`, `PreModel` and [`Model`](@ref CTModels.OCP.Model).
+See also: [`CTModels.OCP.ConstraintsModel`](@ref), [`CTModels.OCP.PreModel`](@ref),
+[`CTModels.OCP.Model`](@ref).
 """
 const ConstraintsDictType = OrderedDict{
     Symbol,Tuple{Symbol,Union{Function,OrdinalRange{<:Int}},ctVector,ctVector}

--- a/src/Serialization/Serialization.jl
+++ b/src/Serialization/Serialization.jl
@@ -25,7 +25,8 @@ The following are internal utilities (accessible via `Serialization.function_nam
 - `__format`: Get default format
 - `__filename_export_import`: Get default filename
 
-See also: `CTModels`, `export_ocp_solution`, `import_ocp_solution`
+See also: [`CTModels.Serialization.export_ocp_solution`](@ref),
+[`CTModels.Serialization.import_ocp_solution`](@ref).
 """
 module Serialization
 

--- a/src/Serialization/export_import.jl
+++ b/src/Serialization/export_import.jl
@@ -19,7 +19,7 @@ function import_ocp_solution(::JSON3Tag, ::AbstractModel; filename::String)
 end
 
 """
-    export_ocp_solution(sol; format=:JLD, filename="solution")
+$(TYPEDSIGNATURES)
 
 Export an optimal control solution to a file.
 
@@ -33,7 +33,7 @@ Export an optimal control solution to a file.
 # Notes
 Requires loading the appropriate package (`JLD2` or `JSON3`) before use.
 
-See also: `import_ocp_solution`
+See also: [`CTModels.Serialization.import_ocp_solution`](@ref).
 """
 function export_ocp_solution(
     sol::AbstractSolution;
@@ -58,7 +58,7 @@ function export_ocp_solution(
 end
 
 """
-    import_ocp_solution(ocp; format=:JLD, filename="solution")
+$(TYPEDSIGNATURES)
 
 Import an optimal control solution from a file.
 
@@ -75,7 +75,7 @@ Import an optimal control solution from a file.
 # Notes
 Requires loading the appropriate package (`JLD2` or `JSON3`) before use.
 
-See also: `export_ocp_solution`
+See also: [`CTModels.Serialization.export_ocp_solution`](@ref).
 """
 function import_ocp_solution(
     ocp::AbstractModel;

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -21,7 +21,6 @@ The following are internal utilities (accessible via `Utils.function_name`):
 - `to_out_of_place`: Convert in-place functions to out-of-place
 - `@ensure`: Validation macro for preconditions
 
-See also: `CTModels`
 """
 module Utils
 


### PR DESCRIPTION
## Summary

- Add `@ref` cross-references in docstrings for better navigation
- Reorganize API reference file structure (move `definition.jl` to Components)
- Add Display module files to API reference (ansi, definition, mathematical, model, pre_model)
- Add `reconstruction_helpers.jl` to Serialization API reference
- Update module overview table in index.md
- Simplify CTModels.jl main module docstring with tables
- Fix "See also" references to use qualified paths with `@ref`
- Add AGENTS.md, CLAUDE.md and dev/ directory

## Changes

### Documentation improvements
- Improved docstrings with proper `@ref` cross-references for better documentation navigation
- Reorganized API reference structure for better logical grouping
- Added comprehensive module overview table in index.md

### New developer resources
- `AGENTS.md`: Agent navigation guide for CTFlows.jl
- `CLAUDE.md`: Claude-specific documentation
- `dev/`: Development resources (philosophy, rules, planning, reports)

## Testing

No code changes - documentation only.