### PR TITLE
refactor: move shared accessor ownership to Components

### DIFF
--- a/src/Components/Components.jl
+++ b/src/Components/Components.jl
@@ -34,6 +34,7 @@ using OrderedCollections: OrderedCollections
 include(joinpath(@__DIR__, "functors.jl"))
 include(joinpath(@__DIR__, "aliases.jl"))
 include(joinpath(@__DIR__, "types.jl"))
+include(joinpath(@__DIR__, "accessors_api.jl"))
 include(joinpath(@__DIR__, "accessors.jl"))
 include(joinpath(@__DIR__, "times_accessors.jl"))
 include(joinpath(@__DIR__, "objective_accessors.jl"))
@@ -70,6 +71,9 @@ export AbstractDefinition, EmptyDefinition, Definition
 
 # Component accessor functions (name/dim/value/etc.)
 export name, components, dimension, value, interpolation, expression
+
+# Shared high-level component accessors (state/costate, control, variable, objective, times axis)
+export state, control, variable, objective, costate, times, time_grid
 
 # Time model accessors
 export index, initial, final

--- a/src/Components/accessors_api.jl
+++ b/src/Components/accessors_api.jl
@@ -1,0 +1,9 @@
+# Shared high-level component accessor generics, declared and owned by Components.
+# Models / Solutions / Init attach their own methods to these generics.
+function state end
+function control end
+function variable end
+function objective end
+function costate end
+function times end
+function time_grid end

--- a/src/Display/solution.jl
+++ b/src/Display/solution.jl
@@ -22,7 +22,7 @@ function Base.show(io::IO, ::MIME"text/plain", sol::Solutions.Solution)
     println(io, "  │  Status     : ", Solutions.status(sol))
     println(io, "  │  Message    : ", Solutions.message(sol))
     println(io, "  │  Iterations : ", Solutions.iterations(sol))
-    println(io, "  │  Objective  : ", Models.objective(sol))
+    println(io, "  │  Objective  : ", Components.objective(sol))
     println(io, "  └─ Constraints violation : ", Solutions.constraints_violation(sol))
 
     # Variable (if defined)
@@ -32,7 +32,7 @@ function Base.show(io::IO, ::MIME"text/plain", sol::Solutions.Solution)
 
         # Simplified case: dimension 1 and name identical
         if Models.variable_dimension(sol) == 1 && var_name == components[1]
-            println(io, "\n• Variable: ", var_name, " = ", Models.variable(sol))
+            println(io, "\n• Variable: ", var_name, " = ", Components.variable(sol))
         else
             println(
                 io,
@@ -41,7 +41,7 @@ function Base.show(io::IO, ::MIME"text/plain", sol::Solutions.Solution)
                 " = (",
                 join(components, ", "),
                 ") = ",
-                Models.variable(sol),
+                Components.variable(sol),
             )
         end
         if Solutions.dim_dual_variable_constraints_box(sol) > 0 &&

--- a/src/Init/control.jl
+++ b/src/Init/control.jl
@@ -168,7 +168,7 @@ Return the control trajectory from an initial guess.
 # Returns
 - `Function`: The control function `t -> u(t)`.
 """
-Models.control(init::AbstractInitialGuess) = init.control
+Components.control(init::AbstractInitialGuess) = init.control
 
 """
 $(TYPEDSIGNATURES)
@@ -181,4 +181,4 @@ Return the control trajectory from a solution.
 # Returns
 - `Function`: The control function `t -> u(t)`.
 """
-Models.control(sol::Solutions.AbstractSolution) = sol.control
+Components.control(sol::Solutions.AbstractSolution) = sol.control

--- a/src/Init/state.jl
+++ b/src/Init/state.jl
@@ -145,7 +145,7 @@ Return the state trajectory from an initial guess.
 # Returns
 - `Function`: The state function `t -> x(t)`.
 """
-Models.state(init::AbstractInitialGuess) = init.state
+Components.state(init::AbstractInitialGuess) = init.state
 
 """
 $(TYPEDSIGNATURES)
@@ -158,4 +158,4 @@ Return the state trajectory from a solution.
 # Returns
 - `Function`: The state function `t -> x(t)`.
 """
-Models.state(sol::Solutions.AbstractSolution) = sol.state
+Components.state(sol::Solutions.AbstractSolution) = sol.state

--- a/src/Init/validation.jl
+++ b/src/Init/validation.jl
@@ -24,7 +24,7 @@ function _validate_initial_guess(ocp::Models.AbstractModel, init::InitialGuess)
 
     # Sample evaluation time; for autonomous/non-autonomous problems
     # the shape of x(t), u(t) is independent of t.
-    v0 = Models.variable(init)
+    v0 = Components.variable(init)
     tsample = if Components.has_fixed_initial_time(ocp)
         Components.initial_time(ocp)
     else
@@ -32,7 +32,7 @@ function _validate_initial_guess(ocp::Models.AbstractModel, init::InitialGuess)
     end
 
     # State
-    x0 = Models.state(init)(tsample)
+    x0 = Components.state(init)(tsample)
     if xdim == 1
         if !(x0 isa Real) && !(x0 isa AbstractVector && length(x0) == 1)
             throw(
@@ -60,7 +60,7 @@ function _validate_initial_guess(ocp::Models.AbstractModel, init::InitialGuess)
     end
 
     # Control
-    u0 = Models.control(init)(tsample)
+    u0 = Components.control(init)(tsample)
     if udim == 1
         if !(u0 isa Real) && !(u0 isa AbstractVector && length(u0) == 1)
             throw(
@@ -194,9 +194,9 @@ function _initial_guess_from_solution(
         )
     end
 
-    state_fun = Models.state(sol)
-    control_fun = Models.control(sol)
-    variable_val = Models.variable(sol)
+    state_fun = Components.state(sol)
+    control_fun = Components.control(sol)
+    variable_val = Components.variable(sol)
 
     return InitialGuess(state_fun, control_fun, variable_val)
 end

--- a/src/Init/variable.jl
+++ b/src/Init/variable.jl
@@ -142,4 +142,4 @@ Return the variable value from an initial guess.
 # Returns
 - `Union{Real, Vector{<:Real}}`: The variable value (scalar or vector).
 """
-Models.variable(init::AbstractInitialGuess) = init.variable
+Components.variable(init::AbstractInitialGuess) = init.variable

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -50,8 +50,8 @@ export is_variable, is_nonvariable, is_control_free
 export has_variable, has_control
 export has_abstract_definition, is_abstractly_defined
 
-# Component field accessors (return sub-model structs)
-export state, control, variable, times, objective, constraints, dynamics, definition
+# Component field accessors (return sub-model structs) — state/control/variable/times/objective owned by Components
+export constraints, dynamics, definition
 
 # Named accessors on state/control/variable
 export state_name, state_components, state_dimension

--- a/src/Models/model.jl
+++ b/src/Models/model.jl
@@ -296,7 +296,7 @@ Return the state struct.
 
 See also: [`CTModels.Models.state_name`](@ref), [`CTModels.Models.state_components`](@ref), [`CTModels.Models.state_dimension`](@ref).
 """
-function state(
+function Components.state(
     ocp::Model{
         <:TimeDependence,
         <:TimesModel,
@@ -381,7 +381,7 @@ Return the control struct.
 
 See also: [`CTModels.Models.control_name`](@ref), [`CTModels.Models.control_components`](@ref), [`CTModels.Models.control_dimension`](@ref).
 """
-function control(
+function Components.control(
     ocp::Model{
         <:TimeDependence,
         <:TimesModel,
@@ -466,7 +466,7 @@ Return the variable struct.
 
 See also: [`CTModels.Models.variable_name`](@ref), [`CTModels.Models.variable_components`](@ref), [`CTModels.Models.variable_dimension`](@ref).
 """
-function variable(
+function Components.variable(
     ocp::Model{
         <:TimeDependence,
         <:TimesModel,
@@ -551,7 +551,7 @@ Return the times struct.
 
 See also: [`CTModels.Components.time_name`](@ref), [`CTModels.Components.initial_time`](@ref), [`CTModels.Components.final_time`](@ref).
 """
-function times(
+function Components.times(
     ocp::Model{
         <:TimeDependence,
         T,
@@ -946,7 +946,7 @@ Return the objective struct.
 
 See also: [`CTModels.Components.criterion`](@ref), [`CTModels.Components.mayer`](@ref), [`CTModels.Components.lagrange`](@ref).
 """
-function objective(
+function Components.objective(
     ocp::Model{
         <:TimeDependence,
         <:AbstractTimesModel,

--- a/src/Solutions/Solutions.jl
+++ b/src/Solutions/Solutions.jl
@@ -90,13 +90,11 @@ export UnifiedTimeGridModel, MultipleTimeGridModel
 # build_solution constructor
 export build_solution
 
-# Solution accessors
-export time_grid
+# Solution accessors — costate/time_grid owned by Components
 export clean_component_symbols, time_grid_model
 export control_interpolation
 export dim_dual_state_constraints_box,
     dim_dual_control_constraints_box, dim_dual_variable_constraints_box
-export costate
 export dual
 export iterations, status, message, success, successful
 export constraints_violation, infos

--- a/src/Solutions/build_solution.jl
+++ b/src/Solutions/build_solution.jl
@@ -645,7 +645,7 @@ julia> x0 = x(t0) # state at the initial time
 
 See also: [`CTModels.Models.state_dimension`](@ref), [`CTModels.Models.state_components`](@ref).
 """
-function Models.state(
+function Components.state(
     sol::Solution{
         <:AbstractTimeGridModel,
         <:AbstractTimesModel,
@@ -750,7 +750,7 @@ julia> u0 = u(t0) # control at the initial time
 
 See also: [`CTModels.Models.control_dimension`](@ref), [`CTModels.Models.control_components`](@ref).
 """
-function Models.control(
+function Components.control(
     sol::Solution{
         <:AbstractTimeGridModel,
         <:AbstractTimesModel,
@@ -946,7 +946,7 @@ julia> v = CTModels.variable(sol)
 
 See also: [`CTModels.Models.variable_dimension`](@ref), [`CTModels.Models.variable_components`](@ref).
 """
-function Models.variable(
+function Components.variable(
     sol::Solution{
         <:AbstractTimeGridModel,
         <:AbstractTimesModel,
@@ -983,7 +983,7 @@ julia> p0 = p(t0) # costate at the initial time
 
 See also: [`CTModels.Models.state`](@ref), [`CTModels.Solutions.dual`](@ref).
 """
-function costate(
+function Components.costate(
     sol::Solution{
         <:AbstractTimeGridModel,
         <:AbstractTimesModel,
@@ -1167,7 +1167,7 @@ Return the times model.
 
 See also: [`CTModels.Components.initial_time`](@ref), [`CTModels.Components.final_time`](@ref).
 """
-function Models.times(
+function Components.times(
     sol::Solution{
         <:AbstractTimeGridModel,
         TM,
@@ -1197,7 +1197,7 @@ Return the time grid for solutions with unified time grid.
 
 See also: [`CTModels.Solutions.time_grid(sol, component)`](@ref), [`CTModels.Models.times`](@ref).
 """
-function time_grid(
+function Components.time_grid(
     sol::Solution{
         <:UnifiedTimeGridModel{T},
         <:AbstractTimesModel,
@@ -1244,7 +1244,7 @@ julia> time_grid(sol, :costate) # Maps to :state grid
 julia> time_grid(sol, :dual)    # Maps to :path grid
 ```
 """
-function time_grid(
+function Components.time_grid(
     sol::Solution{
         <:UnifiedTimeGridModel{T},
         <:AbstractTimesModel,
@@ -1306,7 +1306,7 @@ julia> time_grid(sol, :costate) # Maps to state time grid
 julia> time_grid(sol, :dual)    # Maps to path time grid
 ```
 """
-function time_grid(
+function Components.time_grid(
     sol::Solution{
         <:MultipleTimeGridModel,
         <:AbstractTimesModel,
@@ -1348,7 +1348,7 @@ $(TYPEDSIGNATURES)
 Return the objective value.
 
 """
-function Models.objective(
+function Components.objective(
     sol::Solution{
         <:AbstractTimeGridModel,
         <:AbstractTimesModel,

--- a/test/suite/serialization/test_export_import.jl
+++ b/test/suite/serialization/test_export_import.jl
@@ -133,32 +133,32 @@ function compare_solutions(
     end
 
     # Compare time grid
-    T1 = Solutions.time_grid(sol1)
-    T2 = Solutions.time_grid(sol2)
+    T1 = Components.time_grid(sol1)
+    T2 = Components.time_grid(sol2)
     if !isapprox(T1, T2; atol=atol_numerical)
         return false
     end
 
     # Compare variable
-    v1 = Models.variable(sol1)
-    v2 = Models.variable(sol2)
+    v1 = Components.variable(sol1)
+    v2 = Components.variable(sol2)
     if !isapprox(v1, v2; atol=atol_numerical)
         return false
     end
 
     # Compare trajectories at time grid points
     if !compare_trajectories(
-        Models.state(sol1), Models.state(sol2), T1; atol=atol_trajectories
+        Components.state(sol1), Components.state(sol2), T1; atol=atol_trajectories
     )
         return false
     end
     if !compare_trajectories(
-        Models.control(sol1), Models.control(sol2), T1; atol=atol_trajectories
+        Components.control(sol1), Components.control(sol2), T1; atol=atol_trajectories
     )
         return false
     end
     if !compare_trajectories(
-        Solutions.costate(sol1), Solutions.costate(sol2), T1; atol=atol_trajectories
+        Components.costate(sol1), Components.costate(sol2), T1; atol=atol_trajectories
     )
         return false
     end
@@ -360,13 +360,13 @@ function test_export_import()
             Test.@test blob["successful"] == Solutions.successful(sol)
 
             # Verify time_grid
-            T_orig = Solutions.time_grid(sol)
+            T_orig = Components.time_grid(sol)
             T_json = Vector{Float64}(blob["time_grid"])
             Test.@test length(T_json) == length(T_orig)
             Test.@test T_json ≈ T_orig atol = 1e-10
 
             # Verify variable
-            v_orig = Models.variable(sol)
+            v_orig = Components.variable(sol)
             v_json = if isempty(blob["variable"])
                 Float64[]
             else
@@ -377,7 +377,7 @@ function test_export_import()
             # Verify state discretization
             state_json = blob["state"]
             Test.@test length(state_json) == length(T_orig)
-            x_func = Models.state(sol)
+            x_func = Components.state(sol)
             for (i, t) in enumerate(T_orig)
                 x_expected = x_func(t)
                 # After fix: state_json[i] is always a vector (even for 1D states)
@@ -392,7 +392,7 @@ function test_export_import()
             # Verify control discretization
             control_json = blob["control"]
             Test.@test length(control_json) == length(T_orig)
-            u_func = Models.control(sol)
+            u_func = Components.control(sol)
             for (i, t) in enumerate(T_orig)
                 u_expected = u_func(t)
                 # After fix: control_json[i] is always a vector (even for 1D controls)
@@ -407,7 +407,7 @@ function test_export_import()
             # Verify costate discretization
             costate_json = blob["costate"]
             Test.@test length(costate_json) == length(T_orig)
-            p_func = Solutions.costate(sol)
+            p_func = Components.costate(sol)
             for (i, t) in enumerate(T_orig)
                 p_expected = p_func(t)
                 # After fix: costate_json[i] is always a vector
@@ -483,7 +483,7 @@ function test_export_import()
             Test.@test Solutions.successful(sol_reloaded) == Solutions.successful(sol)
 
             # Time grid
-            Test.@test Solutions.time_grid(sol_reloaded) ≈ Solutions.time_grid(sol) atol =
+            Test.@test Components.time_grid(sol_reloaded) ≈ Components.time_grid(sol) atol =
                 1e-10
 
             # Metadata: dimensions, names, components and time labels
@@ -510,26 +510,26 @@ function test_export_import()
             Test.@test Components.time_name(sol_reloaded) == Components.time_name(sol)
 
             # Variable
-            Test.@test Models.variable(sol_reloaded) ≈ Models.variable(sol) atol = 1e-10
+            Test.@test Components.variable(sol_reloaded) ≈ Components.variable(sol) atol = 1e-10
 
             # State at sample times
-            T = Solutions.time_grid(sol)
-            x_orig = Models.state(sol)
-            x_reload = Models.state(sol_reloaded)
+            T = Components.time_grid(sol)
+            x_orig = Components.state(sol)
+            x_reload = Components.state(sol_reloaded)
             for t in T
                 Test.@test x_reload(t) ≈ x_orig(t) atol = 1e-8
             end
 
             # Control at sample times
-            u_orig = Models.control(sol)
-            u_reload = Models.control(sol_reloaded)
+            u_orig = Components.control(sol)
+            u_reload = Components.control(sol_reloaded)
             for t in T
                 Test.@test u_reload(t) ≈ u_orig(t) atol = 1e-8
             end
 
             # Costate at sample times
-            p_orig = Solutions.costate(sol)
-            p_reload = Solutions.costate(sol_reloaded)
+            p_orig = Components.costate(sol)
+            p_reload = Components.costate(sol_reloaded)
             for t in T
                 Test.@test p_reload(t) ≈ p_orig(t) atol = 1e-8
             end
@@ -672,13 +672,13 @@ function test_export_import()
         Test.@testset "JSON: solver infos dict preserved" begin
             # Create a solution with custom infos
             ocp, sol_base = TestProblems.solution_example()
-            T = Solutions.time_grid(sol_base)
+            T = Components.time_grid(sol_base)
 
             # Build a new solution with custom infos
-            x = Models.state(sol_base)
-            u = Models.control(sol_base)
-            p = Solutions.costate(sol_base)
-            v = Models.variable(sol_base)
+            x = Components.state(sol_base)
+            u = Components.control(sol_base)
+            p = Components.costate(sol_base)
+            v = Components.variable(sol_base)
 
             custom_infos = Dict{Symbol,Any}(
                 :solver_name => "TestSolver",
@@ -834,13 +834,13 @@ function test_export_import()
         Test.@testset "JSON idempotence: with complex infos" verbose = VERBOSE showtiming =
             SHOWTIMING begin
             ocp, sol_base = TestProblems.solution_example()
-            T = Solutions.time_grid(sol_base)
+            T = Components.time_grid(sol_base)
 
             # Build solution with complex infos
-            x = Models.state(sol_base)
-            u = Models.control(sol_base)
-            p = Solutions.costate(sol_base)
-            v = Models.variable(sol_base)
+            x = Components.state(sol_base)
+            u = Components.control(sol_base)
+            p = Components.costate(sol_base)
+            v = Components.variable(sol_base)
 
             complex_infos = Dict{Symbol,Any}(
                 :solver_name => "TestSolver",
@@ -1046,13 +1046,13 @@ function test_export_import()
         Test.@testset "Control interpolation preservation: JSON" verbose = VERBOSE showtiming =
             SHOWTIMING begin
             ocp, sol_base = TestProblems.solution_example()
-            T = Solutions.time_grid(sol_base)
+            T = Components.time_grid(sol_base)
 
             # Extract trajectories
-            x = Models.state(sol_base)
-            u = Models.control(sol_base)
-            p = Solutions.costate(sol_base)
-            v = Models.variable(sol_base)
+            x = Components.state(sol_base)
+            u = Components.control(sol_base)
+            p = Components.costate(sol_base)
+            v = Components.variable(sol_base)
 
             # Test with constant interpolation (default)
             sol_constant = Solutions.build_solution(
@@ -1113,8 +1113,8 @@ function test_export_import()
             Test.@test Solutions.control_interpolation(sol_linear_reloaded) == :linear
 
             # Verify control behavior is preserved (linear vs constant)
-            u_const = Models.control(sol_constant_reloaded)
-            u_linear = Models.control(sol_linear_reloaded)
+            u_const = Components.control(sol_constant_reloaded)
+            u_linear = Components.control(sol_linear_reloaded)
 
             # At midpoint, linear should differ from constant
             if length(T) >= 2
@@ -1133,13 +1133,13 @@ function test_export_import()
         Test.@testset "Control interpolation preservation: JLD2" verbose = VERBOSE showtiming =
             SHOWTIMING begin
             ocp, sol_base = TestProblems.solution_example()
-            T = Solutions.time_grid(sol_base)
+            T = Components.time_grid(sol_base)
 
             # Extract trajectories
-            x = Models.state(sol_base)
-            u = Models.control(sol_base)
-            p = Solutions.costate(sol_base)
-            v = Models.variable(sol_base)
+            x = Components.state(sol_base)
+            u = Components.control(sol_base)
+            p = Components.costate(sol_base)
+            v = Components.variable(sol_base)
 
             # Test with constant interpolation (default)
             sol_constant = Solutions.build_solution(
@@ -1200,8 +1200,8 @@ function test_export_import()
             Test.@test Solutions.control_interpolation(sol_linear_reloaded) == :linear
 
             # Verify control behavior is preserved (linear vs constant)
-            u_const = Models.control(sol_constant_reloaded)
-            u_linear = Models.control(sol_linear_reloaded)
+            u_const = Components.control(sol_constant_reloaded)
+            u_linear = Components.control(sol_linear_reloaded)
 
             # At midpoint, linear should differ from constant
             if length(T) >= 2
@@ -1220,13 +1220,13 @@ function test_export_import()
         Test.@testset "Control interpolation backward compatibility" verbose = VERBOSE showtiming =
             SHOWTIMING begin
             ocp, sol_base = TestProblems.solution_example()
-            T = Solutions.time_grid(sol_base)
+            T = Components.time_grid(sol_base)
 
             # Extract trajectories
-            x = Models.state(sol_base)
-            u = Models.control(sol_base)
-            p = Solutions.costate(sol_base)
-            v = Models.variable(sol_base)
+            x = Components.state(sol_base)
+            u = Components.control(sol_base)
+            p = Components.costate(sol_base)
+            v = Components.variable(sol_base)
 
             # Create solution without control_interpolation (old format)
             sol_old = Solutions.build_solution(
@@ -1280,13 +1280,13 @@ function test_export_import()
         Test.@testset "Control interpolation mixed format compatibility" verbose = VERBOSE showtiming =
             SHOWTIMING begin
             ocp, sol_base = TestProblems.solution_example()
-            T = Solutions.time_grid(sol_base)
+            T = Components.time_grid(sol_base)
 
             # Extract trajectories
-            x = Models.state(sol_base)
-            u = Models.control(sol_base)
-            p = Solutions.costate(sol_base)
-            v = Models.variable(sol_base)
+            x = Components.state(sol_base)
+            u = Components.control(sol_base)
+            p = Components.costate(sol_base)
+            v = Components.variable(sol_base)
 
             # Create solution with linear interpolation
             sol_linear = Solutions.build_solution(
@@ -1327,9 +1327,9 @@ function test_export_import()
             Test.@test Solutions.control_interpolation(sol_jld_reloaded) == :linear
 
             # Verify control functions behave identically
-            u_orig = Models.control(sol_linear)
-            u_json = Models.control(sol_json_reloaded)
-            u_jld = Models.control(sol_jld_reloaded)
+            u_orig = Components.control(sol_linear)
+            u_json = Components.control(sol_json_reloaded)
+            u_jld = Components.control(sol_jld_reloaded)
 
             for t in T[1:min(end, 3)]  # Test first few points
                 Test.@test u_orig(t) ≈ u_json(t) atol=1e-10

--- a/test/suite/serialization/test_multi_grids.jl
+++ b/test/suite/serialization/test_multi_grids.jl
@@ -4,6 +4,7 @@ import Test: Test
 import JLD2: JLD2
 import JSON3: JSON3
 import CTBase.Exceptions: Exceptions
+import CTModels.Components: Components
 import CTModels.Models: Models
 import CTModels.Solutions: Solutions
 import CTModels.Serialization: Serialization
@@ -29,11 +30,11 @@ function test_multi_grids()
         ocp, sol_unified = TestProblems.solution_example()
 
         # Extract data from unified solution
-        T_unified = Solutions.time_grid(sol_unified)
-        X = Models.state(sol_unified).(T_unified)
-        U = Models.control(sol_unified).(T_unified)
-        P = Solutions.costate(sol_unified).(T_unified)
-        v = Models.variable(sol_unified)
+        T_unified = Components.time_grid(sol_unified)
+        X = Components.state(sol_unified).(T_unified)
+        U = Components.control(sol_unified).(T_unified)
+        P = Components.costate(sol_unified).(T_unified)
+        v = Components.variable(sol_unified)
 
         # Convert to matrices
         X_mat = hcat([x for x in X]...)'
@@ -49,9 +50,9 @@ function test_multi_grids()
             T = collect(LinRange(0.0, 1.0, 11))
 
             # Use functions (simpler and more robust)
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol = Solutions.build_solution(
                 ocp,
@@ -75,7 +76,7 @@ function test_multi_grids()
             Test.@test Solutions.time_grid_model(sol) isa Solutions.UnifiedTimeGridModel
 
             # time_grid without argument should work
-            T_retrieved = Solutions.time_grid(sol)
+            T_retrieved = Components.time_grid(sol)
             Test.@test T_retrieved ≈ T
         end
 
@@ -91,9 +92,9 @@ function test_multi_grids()
             T_path = collect(LinRange(0.0, 1.0, 21))      # Fine grid
 
             # Use functions instead of matrices (simpler)
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol_multi = Solutions.build_solution(
                 ocp,
@@ -118,10 +119,10 @@ function test_multi_grids()
                 Solutions.MultipleTimeGridModel
 
             # time_grid with component should work
-            Test.@test Solutions.time_grid(sol_multi, :state) ≈ T_state
-            Test.@test Solutions.time_grid(sol_multi, :control) ≈ T_control
-            Test.@test Solutions.time_grid(sol_multi, :costate) ≈ T_costate
-            Test.@test Solutions.time_grid(sol_multi, :dual) ≈ T_path
+            Test.@test Components.time_grid(sol_multi, :state) ≈ T_state
+            Test.@test Components.time_grid(sol_multi, :control) ≈ T_control
+            Test.@test Components.time_grid(sol_multi, :costate) ≈ T_costate
+            Test.@test Components.time_grid(sol_multi, :dual) ≈ T_path
         end
 
         # ====================================================================
@@ -136,9 +137,9 @@ function test_multi_grids()
             T_path = collect(LinRange(0.0, 1.0, 21))
             # T_path same as T_state for this test
 
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol_multi = Solutions.build_solution(
                 ocp,
@@ -173,21 +174,21 @@ function test_multi_grids()
                 Solutions.MultipleTimeGridModel
 
             # Verify grids are preserved
-            Test.@test Solutions.time_grid(sol_reloaded, :state) ≈ T_state
-            Test.@test Solutions.time_grid(sol_reloaded, :control) ≈ T_control
-            Test.@test Solutions.time_grid(sol_reloaded, :costate) ≈ T_costate
-            Test.@test Solutions.time_grid(sol_reloaded, :dual) ≈ T_path
+            Test.@test Components.time_grid(sol_reloaded, :state) ≈ T_state
+            Test.@test Components.time_grid(sol_reloaded, :control) ≈ T_control
+            Test.@test Components.time_grid(sol_reloaded, :costate) ≈ T_costate
+            Test.@test Components.time_grid(sol_reloaded, :dual) ≈ T_path
 
             # Verify data integrity
             Test.@test Solutions.objective(sol_reloaded) ≈ Solutions.objective(sol_multi)
-            Test.@test Models.variable(sol_reloaded) ≈ Models.variable(sol_multi)
+            Test.@test Components.variable(sol_reloaded) ≈ Components.variable(sol_multi)
 
             # Verify trajectories at their respective grids
             for t in T_state
-                Test.@test Models.state(sol_reloaded)(t) ≈ Models.state(sol_multi)(t) atol=1e-8
+                Test.@test Components.state(sol_reloaded)(t) ≈ Components.state(sol_multi)(t) atol=1e-8
             end
             for t in T_control
-                Test.@test Models.control(sol_reloaded)(t) ≈ Models.control(sol_multi)(t) atol=1e-8
+                Test.@test Components.control(sol_reloaded)(t) ≈ Components.control(sol_multi)(t) atol=1e-8
             end
 
             remove_if_exists("multi_grid_test.jld2")
@@ -204,9 +205,9 @@ function test_multi_grids()
             T_costate = collect(LinRange(0.0, 1.0, 16))
             T_path = collect(LinRange(0.0, 1.0, 21))
 
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol_multi = Solutions.build_solution(
                 ocp,
@@ -227,12 +228,12 @@ function test_multi_grids()
             )
 
             # time_grid without component should return state grid (default behavior)
-            Test.@test Solutions.time_grid(sol_multi) == T_state
-            Test.@test Solutions.time_grid(sol_multi) ==
-                Solutions.time_grid(sol_multi, :state)
+            Test.@test Components.time_grid(sol_multi) == T_state
+            Test.@test Components.time_grid(sol_multi) ==
+                Components.time_grid(sol_multi, :state)
 
             # Invalid component should throw error
-            Test.@test_throws Exceptions.IncorrectArgument Solutions.time_grid(
+            Test.@test_throws Exceptions.IncorrectArgument Components.time_grid(
                 sol_multi, :invalid
             )
         end
@@ -248,9 +249,9 @@ function test_multi_grids()
             T_costate = collect(LinRange(0.0, 1.0, 16))
             T_path = collect(LinRange(0.0, 1.0, 21))
 
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol_multi = Solutions.build_solution(
                 ocp,
@@ -271,13 +272,13 @@ function test_multi_grids()
             )
 
             # Test plural forms work
-            Test.@test Solutions.time_grid(sol_multi, :states) ≈ T_state
-            Test.@test Solutions.time_grid(sol_multi, :controls) ≈ T_control
-            Test.@test Solutions.time_grid(sol_multi, :costates) ≈ T_costate
+            Test.@test Components.time_grid(sol_multi, :states) ≈ T_state
+            Test.@test Components.time_grid(sol_multi, :controls) ≈ T_control
+            Test.@test Components.time_grid(sol_multi, :costates) ≈ T_costate
 
             # Test path/dual equivalence
-            Test.@test Solutions.time_grid(sol_multi, :path) ≈ T_path
-            Test.@test Solutions.time_grid(sol_multi, :dual) ≈ T_path
+            Test.@test Components.time_grid(sol_multi, :path) ≈ T_path
+            Test.@test Components.time_grid(sol_multi, :dual) ≈ T_path
         end
 
         # ====================================================================
@@ -290,9 +291,9 @@ function test_multi_grids()
             T_control = collect(LinRange(0.0, 1.0, 11))
             T_costate = collect(LinRange(0.0, 1.0, 11))
 
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol = Solutions.build_solution(
                 ocp,
@@ -314,7 +315,7 @@ function test_multi_grids()
 
             # Should still work (uses T_state for dual)
             Test.@test Solutions.time_grid_model(sol) isa Solutions.UnifiedTimeGridModel
-            Test.@test Solutions.time_grid(sol) ≈ T_state
+            Test.@test Components.time_grid(sol) ≈ T_state
         end
 
         # ====================================================================
@@ -325,9 +326,9 @@ function test_multi_grids()
             # When all grids are identical, should optimize to UnifiedTimeGridModel
             T = collect(LinRange(0.0, 1.0, 11))
 
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             # Pass same grid 4 times
             sol = Solutions.build_solution(
@@ -350,7 +351,7 @@ function test_multi_grids()
 
             # Should detect and optimize to UnifiedTimeGridModel
             Test.@test Solutions.time_grid_model(sol) isa Solutions.UnifiedTimeGridModel
-            Test.@test Solutions.time_grid(sol) ≈ T
+            Test.@test Components.time_grid(sol) ≈ T
 
             # Now with different grids
             T_control_diff = collect(LinRange(0.0, 1.0, 6))
@@ -376,8 +377,8 @@ function test_multi_grids()
             # Should use MultipleTimeGridModel
             Test.@test Solutions.time_grid_model(sol_multi) isa
                 Solutions.MultipleTimeGridModel
-            Test.@test Solutions.time_grid(sol_multi, :state) ≈ T
-            Test.@test Solutions.time_grid(sol_multi, :control) ≈ T_control_diff
+            Test.@test Components.time_grid(sol_multi, :state) ≈ T
+            Test.@test Components.time_grid(sol_multi, :control) ≈ T_control_diff
         end
 
         # ====================================================================
@@ -387,9 +388,9 @@ function test_multi_grids()
         Test.@testset "Serialization structure" begin
             # Test UnifiedTimeGridModel serialization
             T = collect(LinRange(0.0, 1.0, 11))
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol_uni = Solutions.build_solution(
                 ocp,
@@ -463,9 +464,9 @@ function test_multi_grids()
         # ====================================================================
 
         Test.@testset "Extreme grid sizes" begin
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             # Very different grid sizes
             T_state_large = collect(LinRange(0.0, 1.0, 1001))  # Fine grid
@@ -496,10 +497,10 @@ function test_multi_grids()
                 Solutions.MultipleTimeGridModel
 
             # Verify grids
-            Test.@test length(Solutions.time_grid(sol_extreme, :state)) == 1001
-            Test.@test length(Solutions.time_grid(sol_extreme, :control)) == 11
-            Test.@test Solutions.time_grid(sol_extreme, :state) ≈ T_state_large
-            Test.@test Solutions.time_grid(sol_extreme, :control) ≈ T_control_small
+            Test.@test length(Components.time_grid(sol_extreme, :state)) == 1001
+            Test.@test length(Components.time_grid(sol_extreme, :control)) == 11
+            Test.@test Components.time_grid(sol_extreme, :state) ≈ T_state_large
+            Test.@test Components.time_grid(sol_extreme, :control) ≈ T_control_small
 
             # Minimum grid size (2 points)
             T_min = collect(LinRange(0.0, 1.0, 2))
@@ -524,7 +525,7 @@ function test_multi_grids()
 
             # Should work with minimum grid
             Test.@test Solutions.time_grid_model(sol_min) isa Solutions.UnifiedTimeGridModel
-            Test.@test length(Solutions.time_grid(sol_min)) == 2
+            Test.@test length(Components.time_grid(sol_min)) == 2
         end
 
         # ====================================================================
@@ -538,9 +539,9 @@ function test_multi_grids()
             T_costate = collect(LinRange(0.0, 1.0, 16))
             T_path = collect(LinRange(0.0, 1.0, 21))
 
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol_orig = Solutions.build_solution(
                 ocp,
@@ -581,10 +582,10 @@ function test_multi_grids()
             # Verify reconstruction
             Test.@test Solutions.time_grid_model(sol_reconstructed) isa
                 Solutions.MultipleTimeGridModel
-            Test.@test Solutions.time_grid(sol_reconstructed, :state) ≈ T_state
-            Test.@test Solutions.time_grid(sol_reconstructed, :control) ≈ T_control
-            Test.@test Solutions.time_grid(sol_reconstructed, :costate) ≈ T_costate
-            Test.@test Solutions.time_grid(sol_reconstructed, :dual) ≈ T_path
+            Test.@test Components.time_grid(sol_reconstructed, :state) ≈ T_state
+            Test.@test Components.time_grid(sol_reconstructed, :control) ≈ T_control
+            Test.@test Components.time_grid(sol_reconstructed, :costate) ≈ T_costate
+            Test.@test Components.time_grid(sol_reconstructed, :dual) ≈ T_path
             Test.@test Solutions.objective(sol_reconstructed) ≈
                 Solutions.objective(sol_orig)
         end
@@ -596,9 +597,9 @@ function test_multi_grids()
         Test.@testset "Legacy format detection" begin
             # Create a legacy-format data structure (single time_grid)
             T = collect(LinRange(0.0, 1.0, 11))
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol = Solutions.build_solution(
                 ocp,
@@ -643,7 +644,7 @@ function test_multi_grids()
             # Should create UnifiedTimeGridModel from legacy format
             Test.@test Solutions.time_grid_model(sol_from_legacy) isa
                 Solutions.UnifiedTimeGridModel
-            Test.@test Solutions.time_grid(sol_from_legacy) ≈ T
+            Test.@test Components.time_grid(sol_from_legacy) ≈ T
         end
 
         # ====================================================================
@@ -658,9 +659,9 @@ function test_multi_grids()
             T_costate = collect(LinRange(0.0, 1.0, 11))
             T_path = collect(LinRange(0.0, 1.0, 9))
 
-            X_func = Models.state(sol_unified)
-            U_func = Models.control(sol_unified)
-            P_func = Solutions.costate(sol_unified)
+            X_func = Components.state(sol_unified)
+            U_func = Components.control(sol_unified)
+            P_func = Components.costate(sol_unified)
 
             sol_multi = Solutions.build_solution(
                 ocp,
@@ -711,12 +712,12 @@ function test_multi_grids()
             # Verify the solution round-tripped correctly
             Test.@test Solutions.time_grid_model(sol_reimported) isa
                 Solutions.MultipleTimeGridModel
-            Test.@test Solutions.time_grid(sol_reimported, :state) ≈ T_state atol = 1e-10
-            Test.@test Solutions.time_grid(sol_reimported, :control) ≈ T_control atol =
+            Test.@test Components.time_grid(sol_reimported, :state) ≈ T_state atol = 1e-10
+            Test.@test Components.time_grid(sol_reimported, :control) ≈ T_control atol =
                 1e-10
-            Test.@test Solutions.time_grid(sol_reimported, :costate) ≈ T_costate atol =
+            Test.@test Components.time_grid(sol_reimported, :costate) ≈ T_costate atol =
                 1e-10
-            Test.@test Solutions.time_grid(sol_reimported, :dual) ≈ T_path atol = 1e-10
+            Test.@test Components.time_grid(sol_reimported, :dual) ≈ T_path atol = 1e-10
             Test.@test Solutions.objective(sol_reimported) ≈
                 Solutions.objective(sol_unified) atol = 1e-8
 


### PR DESCRIPTION
## Summary

- Déclare 7 génériques partagées (`state`, `control`, `variable`, `objective`, `costate`, `times`, `time_grid`) dans un nouveau fichier `src/Components/accessors_api.jl` — `Components` en est maintenant le propriétaire et l'exporteur unique.
- Requalifie les définitions de méthodes dans `Models`, `Solutions`, `Init` et `Display` : `function Models.state(` → `function Components.state(`, etc.
- Retire ces noms des exports de `Models` et `Solutions` (évite toute ambiguïté à l'import).
- Met à jour les deux fichiers de test de sérialisation qui référençaient directement `Solutions.costate`/`Solutions.time_grid`.
- **API top-level inchangée** : `CTModels.state`, `CTModels.costate`, etc. restent valides via `using .Components` dans `CTModels.jl`.
- **Suite verte** : 3817/3817 tests.

## Contexte

Suite du plan `model_solution_separation_plan.md` (éclatement `OCP` → sous-modules). La décision *« les génériques partagées sont possédées par `Components` »* était actée mais n'avait été appliquée qu'au bas niveau (`name`/`dimension`/`value`). Ce PR l'étend aux accesseurs de haut niveau, éliminant les préfixes trompeurs `Models.objective(sol)` ou `Solutions.costate(sol)` côté appelant.

## Suivi hors-périmètre

- **CTFlows.jl** (repo séparé) : ~9 lignes fonctionnelles à requalifier vers le top-level `CTModels.state`/`CTModels.costate`/`CTModels.objective` — à séquencer après merge.
- Unification `times`/`time_grid` en un seul nom — décision séparée.

## Test plan

- [x] `Pkg.test()` → 3817/3817 passed
- [x] Grep de contrôle : zéro `Models.(state|control|variable|objective|times)` ni `Solutions.(costate|time_grid)` dans `src/` (hors docstrings)
- [ ] Vérifier CTFlows.jl après merge (suivi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)