### PR TITLE
refactor(serialization): simplify solution reconstruction

### DIFF
--- a/ext/CTModelsJLD.jl
+++ b/ext/CTModelsJLD.jl
@@ -88,27 +88,9 @@ function CTModels.import_ocp_solution(
     file_data = JLD2.load(filename * ".jld2")
     data = file_data["solution_data"]
 
-    # Extract solver infos if present
-    infos = if haskey(data, "infos")
-        data["infos"]
-    else
-        Dict{Symbol,Any}()
-    end
+    infos = get(data, "infos", Dict{Symbol,Any}())
 
-    # Reconstruct solution using helper function (handles both single and multiple time grids)
-    sol = CTModels.Serialization._reconstruct_solution_from_data(
-        ocp,
-        data;
-        path_constraints_dual=data["path_constraints_dual"],
-        boundary_constraints_dual=data["boundary_constraints_dual"],
-        state_constraints_lb_dual=data["state_constraints_lb_dual"],
-        state_constraints_ub_dual=data["state_constraints_ub_dual"],
-        control_constraints_lb_dual=data["control_constraints_lb_dual"],
-        control_constraints_ub_dual=data["control_constraints_ub_dual"],
-        variable_constraints_lb_dual=data["variable_constraints_lb_dual"],
-        variable_constraints_ub_dual=data["variable_constraints_ub_dual"],
-        infos=infos,
-    )
+    sol = CTModels.Serialization._reconstruct_solution_from_data(ocp, data; infos=infos)
 
     return sol
 end

--- a/ext/CTModelsJSON.jl
+++ b/ext/CTModelsJSON.jl
@@ -13,7 +13,6 @@ import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using CTModels: CTModels
 using JSON3: JSON3
 
-import CTModels.Building
 
 # ============================================================================
 # Private helpers for JSON matrix conversion
@@ -281,48 +280,17 @@ function CTModels.import_ocp_solution(
     json_string = read(filename * ".json", String)
     blob = JSON3.read(json_string)
 
-    # Convert JSON arrays (Vector{Vector}) back to Matrix{Float64}
-    X = _json_to_matrix(blob["state"])
-    U = _json_to_matrix(blob["control"])
-    P = _json_to_matrix(blob["costate"])
-
-    # Convert optional dual matrices
-    path_constraints_dual = _json_to_optional_matrix(blob["path_constraints_dual"])
-    state_constraints_lb_dual = _json_to_optional_matrix(blob["state_constraints_lb_dual"])
-    state_constraints_ub_dual = _json_to_optional_matrix(blob["state_constraints_ub_dual"])
-    control_constraints_lb_dual = _json_to_optional_matrix(
-        blob["control_constraints_lb_dual"]
-    )
-    control_constraints_ub_dual = _json_to_optional_matrix(
-        blob["control_constraints_ub_dual"]
-    )
-
-    # get dual of boundary constraints: no conversion needed
-    boundary_constraints_dual = blob["boundary_constraints_dual"]
-    if !isnothing(boundary_constraints_dual)
-        boundary_constraints_dual = Vector{Float64}(boundary_constraints_dual)
-    end
-
-    # get variable constraints dual: no conversion needed
-    variable_constraints_lb_dual = blob["variable_constraints_lb_dual"]
-    if !isnothing(variable_constraints_lb_dual)
-        variable_constraints_lb_dual = Vector{Float64}(blob["variable_constraints_lb_dual"])
-    end
-    variable_constraints_ub_dual = blob["variable_constraints_ub_dual"]
-    if !isnothing(variable_constraints_ub_dual)
-        variable_constraints_ub_dual = Vector{Float64}(blob["variable_constraints_ub_dual"])
-    end
-
-    # get additional solver infos with Symbol type restoration
+    # Restore Symbol types in infos (JSON3 deserializes all strings; metadata tracks which were Symbols)
     symbol_keys_raw = get(blob, "infos_symbol_keys", String[])
-    symbol_keys = collect(String, symbol_keys_raw)  # Convert JSON3.Array/empty array to Vector{String}
-    infos = if haskey(blob, "infos")
-        _deserialize_infos(blob["infos"], symbol_keys)
-    else
+    symbol_keys = collect(String, symbol_keys_raw)
+    infos = haskey(blob, "infos") ? _deserialize_infos(blob["infos"], symbol_keys) :
         Dict{Symbol,Any}()
-    end
 
-    # Create data dictionary compatible with helper function
+    # Build data dictionary: convert JSON arrays back to the types expected by the helper
+    bcd = blob["boundary_constraints_dual"]
+    vclbd = blob["variable_constraints_lb_dual"]
+    vcubd = blob["variable_constraints_ub_dual"]
+
     data = Dict{String,Any}(
         "objective" => blob.objective,
         "iterations" => blob.iterations,
@@ -330,59 +298,32 @@ function CTModels.import_ocp_solution(
         "message" => blob.message,
         "status" => blob.status,
         "successful" => blob.successful,
-        "state" => X,
-        "control" => U,
+        "state" => _json_to_matrix(blob["state"]),
+        "control" => _json_to_matrix(blob["control"]),
+        "costate" => _json_to_matrix(blob["costate"]),
         "variable" => Vector{Float64}(blob.variable),
-        "costate" => P,
-        "path_constraints_dual" => path_constraints_dual,
-        "boundary_constraints_dual" => boundary_constraints_dual,
-        "state_constraints_lb_dual" => state_constraints_lb_dual,
-        "state_constraints_ub_dual" => state_constraints_ub_dual,
-        "control_constraints_lb_dual" => control_constraints_lb_dual,
-        "control_constraints_ub_dual" => control_constraints_ub_dual,
-        "variable_constraints_lb_dual" => variable_constraints_lb_dual,
-        "variable_constraints_ub_dual" => variable_constraints_ub_dual,
-        "control_interpolation" => get(
-            blob,
-            "control_interpolation",
-            string(CTModels.Building.__control_interpolation()),
-        ),
+        "path_constraints_dual" => _json_to_optional_matrix(blob["path_constraints_dual"]),
+        "boundary_constraints_dual" => isnothing(bcd) ? nothing : Vector{Float64}(bcd),
+        "state_constraints_lb_dual" => _json_to_optional_matrix(blob["state_constraints_lb_dual"]),
+        "state_constraints_ub_dual" => _json_to_optional_matrix(blob["state_constraints_ub_dual"]),
+        "control_constraints_lb_dual" => _json_to_optional_matrix(blob["control_constraints_lb_dual"]),
+        "control_constraints_ub_dual" => _json_to_optional_matrix(blob["control_constraints_ub_dual"]),
+        "variable_constraints_lb_dual" => isnothing(vclbd) ? nothing : Vector{Float64}(vclbd),
+        "variable_constraints_ub_dual" => isnothing(vcubd) ? nothing : Vector{Float64}(vcubd),
+        "control_interpolation" => blob["control_interpolation"],
     )
 
-    # Add time grid data (format detection handled by helper)
+    # Time grid: multi-grid format (4 separate grids) or unified format (single time_grid)
     if haskey(blob, "time_grid_state")
-        # Multiple time grids format
         data["time_grid_state"] = blob.time_grid_state
         data["time_grid_control"] = blob.time_grid_control
-        # Support time_grid_costate (backward compatibility: if missing, will use T_state in reconstruction)
-        if haskey(blob, "time_grid_costate")
-            data["time_grid_costate"] = blob.time_grid_costate
-        end
-        # Support both new (time_grid_path) and legacy (time_grid_dual) keys
-        if haskey(blob, "time_grid_path")
-            data["time_grid_path"] = blob.time_grid_path
-        elseif haskey(blob, "time_grid_dual")
-            data["time_grid_path"] = blob.time_grid_dual
-        end
+        data["time_grid_costate"] = blob.time_grid_costate
+        data["time_grid_path"] = blob.time_grid_path
     else
-        # Legacy format: single time grid
         data["time_grid"] = blob.time_grid
     end
 
-    # Reconstruct solution using helper function (handles both single and multiple time grids)
-    return CTModels.Serialization._reconstruct_solution_from_data(
-        ocp,
-        data;
-        path_constraints_dual=path_constraints_dual,
-        boundary_constraints_dual=boundary_constraints_dual,
-        state_constraints_lb_dual=state_constraints_lb_dual,
-        state_constraints_ub_dual=state_constraints_ub_dual,
-        control_constraints_lb_dual=control_constraints_lb_dual,
-        control_constraints_ub_dual=control_constraints_ub_dual,
-        variable_constraints_lb_dual=variable_constraints_lb_dual,
-        variable_constraints_ub_dual=variable_constraints_ub_dual,
-        infos=infos,
-    )
+    return CTModels.Serialization._reconstruct_solution_from_data(ocp, data; infos=infos)
 end
 
 end

--- a/src/Serialization/reconstruction_helpers.jl
+++ b/src/Serialization/reconstruction_helpers.jl
@@ -6,68 +6,52 @@ $(TYPEDSIGNATURES)
 
 Reconstruct a solution from imported data, detecting the format (single vs multiple time grids).
 
+Duals and `control_interpolation` are read from `data`. Only `infos` is accepted as a
+keyword argument because its deserialization is format-specific (JSON restores `Symbol` types).
+
 # Arguments
 - `ocp`: The optimal control problem model
-- `data`: Dictionary containing the imported solution data
-- `path_constraints_dual`: Optional path constraints dual function
-- `boundary_constraints_dual`: Optional boundary constraints dual function
-- `state_constraints_lb_dual`: Optional state constraints lower bound dual function
-- `state_constraints_ub_dual`: Optional state constraints upper bound dual function
-- `control_constraints_lb_dual`: Optional control constraints lower bound dual function
-- `control_constraints_ub_dual`: Optional control constraints upper bound dual function
-- `variable_constraints_lb_dual`: Optional variable constraints lower bound dual function
-- `variable_constraints_ub_dual`: Optional variable constraints upper bound dual function
-- `infos`: Optional solver information
+- `data`: Dictionary containing the imported solution data, including all dual fields and
+  `control_interpolation`
+
+# Keyword Arguments
+- `infos`: Solver information dictionary (`Dict{Symbol,Any}`). Passed explicitly because
+  JSON deserialization must restore `Symbol` types before calling this helper.
 
 # Returns
 - `Solution`: Reconstructed solution with appropriate time grid model
 
 # Notes
 - If `time_grid_state` key exists, assumes multiple time grid format
-- Otherwise, uses legacy single time grid format
-- Handles both raw vectors and TimeGridModel objects for legacy format
+- Otherwise, uses the current unified format (single `time_grid` key)
 
 # Example
 ```julia-repl
-julia> sol = _reconstruct_solution_from_data(ocp, data)
+julia> sol = _reconstruct_solution_from_data(ocp, data; infos=infos)
 ```
 
 See also: [`_extract_time_vector`](@ref).
 """
-function _reconstruct_solution_from_data(
-    ocp,
-    data;
-    path_constraints_dual=nothing,
-    boundary_constraints_dual=nothing,
-    state_constraints_lb_dual=nothing,
-    state_constraints_ub_dual=nothing,
-    control_constraints_lb_dual=nothing,
-    control_constraints_ub_dual=nothing,
-    variable_constraints_lb_dual=nothing,
-    variable_constraints_ub_dual=nothing,
-    infos=nothing,
-)
-    # Extract control_interpolation (backward compatibility: use default method)
-    control_interpolation = Symbol(
-        get(data, "control_interpolation", string(Building.__control_interpolation()))
-    )
+function _reconstruct_solution_from_data(ocp, data; infos=Dict{Symbol,Any}())
+    control_interpolation = Symbol(data["control_interpolation"])
+
+    path_constraints_dual = data["path_constraints_dual"]
+    boundary_constraints_dual = data["boundary_constraints_dual"]
+    state_constraints_lb_dual = data["state_constraints_lb_dual"]
+    state_constraints_ub_dual = data["state_constraints_ub_dual"]
+    control_constraints_lb_dual = data["control_constraints_lb_dual"]
+    control_constraints_ub_dual = data["control_constraints_ub_dual"]
+    variable_constraints_lb_dual = data["variable_constraints_lb_dual"]
+    variable_constraints_ub_dual = data["variable_constraints_ub_dual"]
 
     # Detect format and extract time grids
     if haskey(data, "time_grid_state")
         # Multiple time grids format
         T_state = _extract_time_vector(data["time_grid_state"])
         T_control = _extract_time_vector(data["time_grid_control"])
-        # Backward compatibility: if time_grid_costate is missing, use T_state
-        T_costate = if haskey(data, "time_grid_costate")
-            _extract_time_vector(data["time_grid_costate"])
-        else
-            T_state
-        end
-        # Support both new (time_grid_path) and legacy (time_grid_dual) keys
-        T_path_key = haskey(data, "time_grid_path") ? "time_grid_path" : "time_grid_dual"
-        T_path = _extract_time_vector(data[T_path_key])
+        T_costate = _extract_time_vector(data["time_grid_costate"])
+        T_path = _extract_time_vector(data["time_grid_path"])
 
-        # Reconstruct solution with multiple time grids
         return Solutions.build_solution(
             ocp,
             T_state,
@@ -96,25 +80,18 @@ function _reconstruct_solution_from_data(
             control_interpolation=control_interpolation,
         )
     else
-        # Legacy format: single time grid
-        T = if haskey(data, "time_grid")
-            time_grid_data = data["time_grid"]
-            if time_grid_data isa Solutions.TimeGridModel
-                time_grid_data.value
-            else
-                _extract_time_vector(time_grid_data)
-            end
-        else
+        # Current unified format: single time grid
+        if !haskey(data, "time_grid")
             throw(
                 Exceptions.ParsingError(
-                    "legacy solution data is missing the 'time_grid' key";
+                    "solution data is missing the 'time_grid' key";
                     location="imported solution dictionary",
                     suggestion="re-export the solution with a current CTModels version",
                 ),
             )
         end
+        T = _extract_time_vector(data["time_grid"])
 
-        # Reconstruct solution using legacy compatibility (will create UnifiedTimeGridModel)
         return Solutions.build_solution(
             ocp,
             T,

--- a/test/suite/serialization/test_export_import.jl
+++ b/test/suite/serialization/test_export_import.jl
@@ -231,7 +231,7 @@ function compare_solutions(
         return false
     end
 
-    vcubd1 = Solutions.variable_constraints_ub_dual(sol2)
+    vcubd1 = Solutions.variable_constraints_ub_dual(sol1)
     vcubd2 = Solutions.variable_constraints_ub_dual(sol2)
     if isnothing(vcubd1) != isnothing(vcubd2)
         return false
@@ -1217,64 +1217,31 @@ function test_export_import()
             remove_if_exists("test_linear_interp.jld2")
         end
 
-        Test.@testset "Control interpolation backward compatibility" verbose = VERBOSE showtiming =
+        Test.@testset "Missing control_interpolation raises ParsingError" verbose = VERBOSE showtiming =
             SHOWTIMING begin
             ocp, sol_base = TestProblems.solution_example()
-            T = Components.time_grid(sol_base)
 
-            # Extract trajectories
-            x = Components.state(sol_base)
-            u = Components.control(sol_base)
-            p = Components.costate(sol_base)
-            v = Components.variable(sol_base)
-
-            # Create solution without control_interpolation (old format)
-            sol_old = Solutions.build_solution(
-                ocp,
-                Vector{Float64}(T),
-                x,
-                u,
-                isa(v, Number) ? [v] : v,
-                p;
-                objective=Solutions.objective(sol_base),
-                iterations=Solutions.iterations(sol_base),
-                constraints_violation=Solutions.constraints_violation(sol_base),
-                message=Solutions.message(sol_base),
-                status=Solutions.status(sol_base),
-                successful=Solutions.successful(sol_base),
-            )
-
-            # Export to JSON (will not include control_interpolation field)
+            # Export a valid solution
             Serialization.export_ocp_solution(
-                sol_old; filename="test_old_format", format=:JSON
+                sol_base; filename="test_missing_interp", format=:JSON
             )
 
-            # Manually remove control_interpolation from JSON to simulate old format
-            json_string = read("test_old_format.json", String)
+            # Simulate a legacy file by removing control_interpolation from JSON
+            json_string = read("test_missing_interp.json", String)
             json_data = JSON3.read(json_string)
-
-            # Create new JSON without control_interpolation field
-            json_data_without_interp = Dict{String,Any}()
-            for (key, value) in json_data
-                if key != "control_interpolation"
-                    json_data_without_interp[string(key)] = value
-                end
+            json_without = Dict{String,Any}(
+                string(k) => v for (k, v) in json_data if string(k) != "control_interpolation"
+            )
+            open("test_missing_interp.json", "w") do f
+                return JSON3.write(f, json_without)
             end
 
-            # Write back without control_interpolation
-            open("test_old_format.json", "w") do f
-                return JSON3.write(f, json_data_without_interp)
-            end
-
-            # Import should default to :constant
-            sol_old_reloaded = Serialization.import_ocp_solution(
-                ocp; filename="test_old_format", format=:JSON
+            # Import must now raise a KeyError (missing required field)
+            Test.@test_throws KeyError Serialization.import_ocp_solution(
+                ocp; filename="test_missing_interp", format=:JSON
             )
 
-            # Verify backward compatibility (defaults to :constant)
-            Test.@test Solutions.control_interpolation(sol_old_reloaded) == :constant
-
-            remove_if_exists("test_old_format.json")
+            remove_if_exists("test_missing_interp.json")
         end
 
         Test.@testset "Control interpolation mixed format compatibility" verbose = VERBOSE showtiming =

--- a/test/suite/serialization/test_multi_grids.jl
+++ b/test/suite/serialization/test_multi_grids.jl
@@ -566,17 +566,7 @@ function test_multi_grids()
 
             # Reconstruct using helper function
             sol_reconstructed = Serialization._reconstruct_solution_from_data(
-                ocp,
-                data;
-                path_constraints_dual=data["path_constraints_dual"],
-                boundary_constraints_dual=data["boundary_constraints_dual"],
-                state_constraints_lb_dual=data["state_constraints_lb_dual"],
-                state_constraints_ub_dual=data["state_constraints_ub_dual"],
-                control_constraints_lb_dual=data["control_constraints_lb_dual"],
-                control_constraints_ub_dual=data["control_constraints_ub_dual"],
-                variable_constraints_lb_dual=data["variable_constraints_lb_dual"],
-                variable_constraints_ub_dual=data["variable_constraints_ub_dual"],
-                infos=get(data, "infos", Dict{Symbol,Any}()),
+                ocp, data; infos=get(data, "infos", Dict{Symbol,Any}())
             )
 
             # Verify reconstruction
@@ -626,18 +616,10 @@ function test_multi_grids()
             Test.@test haskey(data, "time_grid")
             Test.@test !haskey(data, "time_grid_state")
 
-            # Reconstruct from legacy format
+            # Reconstruct from unified format
             sol_from_legacy = Serialization._reconstruct_solution_from_data(
                 ocp,
                 data;
-                path_constraints_dual=data["path_constraints_dual"],
-                boundary_constraints_dual=data["boundary_constraints_dual"],
-                state_constraints_lb_dual=data["state_constraints_lb_dual"],
-                state_constraints_ub_dual=data["state_constraints_ub_dual"],
-                control_constraints_lb_dual=data["control_constraints_lb_dual"],
-                control_constraints_ub_dual=data["control_constraints_ub_dual"],
-                variable_constraints_lb_dual=data["variable_constraints_lb_dual"],
-                variable_constraints_ub_dual=data["variable_constraints_ub_dual"],
                 infos=get(data, "infos", Dict{Symbol,Any}()),
             )
 
@@ -648,12 +630,11 @@ function test_multi_grids()
         end
 
         # ====================================================================
-        # Test 12: Backward Compatibility - Legacy key time_grid_dual → time_grid_path
-        # The JSON importer supports the old "time_grid_dual" key name that was
-        # used before the rename to "time_grid_path".
+        # Test 12: Missing required time grid keys raise a KeyError
+        # The legacy "time_grid_dual" key is no longer supported.
         # ====================================================================
 
-        Test.@testset "JSON backward compat: time_grid_dual key" begin
+        Test.@testset "JSON missing time_grid_path raises KeyError" begin
             T_state = collect(LinRange(0.0, 1.0, 11))
             T_control = collect(LinRange(0.0, 1.0, 6))
             T_costate = collect(LinRange(0.0, 1.0, 11))
@@ -681,48 +662,30 @@ function test_multi_grids()
                 successful=Solutions.successful(sol_unified),
             )
 
-            # Export to JSON — produces "time_grid_path" key in the blob
+            # Export to JSON — produces "time_grid_path" key
             Serialization.export_ocp_solution(
-                sol_multi; filename="compat_tgd_test", format=:JSON
+                sol_multi; filename="missing_tgp_test", format=:JSON
             )
+            Test.@test isfile("missing_tgp_test.json")
 
-            # Simulate a legacy file by renaming time_grid_path → time_grid_dual
-            json_string = read("compat_tgd_test.json", String)
+            # Simulate a file with the old key name (time_grid_dual) instead of time_grid_path
+            json_string = read("missing_tgp_test.json", String)
             blob = JSON3.read(json_string)
-            Test.@test haskey(blob, "time_grid_path")
-
-            legacy_data = Dict{String,Any}()
-            for (k, val) in blob
-                key_str = string(k)
-                if key_str == "time_grid_path"
-                    legacy_data["time_grid_dual"] = val
-                else
-                    legacy_data[key_str] = val
-                end
-            end
-            open("compat_tgd_legacy.json", "w") do f
+            legacy_data = Dict{String,Any}(
+                string(k) => v for (k, v) in blob if string(k) != "time_grid_path"
+            )
+            legacy_data["time_grid_dual"] = blob["time_grid_path"]  # old name
+            open("missing_tgp_legacy.json", "w") do f
                 return JSON3.write(f, legacy_data)
             end
 
-            # Import from legacy file — should transparently map time_grid_dual
-            sol_reimported = Serialization.import_ocp_solution(
-                ocp; filename="compat_tgd_legacy", format=:JSON
+            # Import from file with old key must raise a KeyError (required key absent)
+            Test.@test_throws KeyError Serialization.import_ocp_solution(
+                ocp; filename="missing_tgp_legacy", format=:JSON
             )
 
-            # Verify the solution round-tripped correctly
-            Test.@test Solutions.time_grid_model(sol_reimported) isa
-                Solutions.MultipleTimeGridModel
-            Test.@test Components.time_grid(sol_reimported, :state) ≈ T_state atol = 1e-10
-            Test.@test Components.time_grid(sol_reimported, :control) ≈ T_control atol =
-                1e-10
-            Test.@test Components.time_grid(sol_reimported, :costate) ≈ T_costate atol =
-                1e-10
-            Test.@test Components.time_grid(sol_reimported, :dual) ≈ T_path atol = 1e-10
-            Test.@test Solutions.objective(sol_reimported) ≈
-                Solutions.objective(sol_unified) atol = 1e-8
-
-            remove_if_exists("compat_tgd_test.json")
-            remove_if_exists("compat_tgd_legacy.json")
+            remove_if_exists("missing_tgp_test.json")
+            remove_if_exists("missing_tgp_legacy.json")
         end
     end
 end

--- a/test/suite/serialization/test_serialization_units.jl
+++ b/test/suite/serialization/test_serialization_units.jl
@@ -185,7 +185,7 @@ function test_serialization_units()
         end
 
         # ==============================================================================
-        # C.4 — Pinning du type reconstruit après import
+        # C.4 — Pinning of reconstructed type after import
         # ==============================================================================
 
         Test.@testset "Reconstructed solution: unified time_grid_model pinning" begin
@@ -233,7 +233,7 @@ function test_serialization_units()
         end
 
         # ==============================================================================
-        # C.5 — Round-trip des duals issus de DualSlice / BoxDualDiff
+        # C.5 — Round-trip of duals from DualSlice / BoxDualDiff
         # ==============================================================================
 
         Test.@testset "Round-trip: duals from DualSlice/BoxDualDiff (JSON)" begin

--- a/test/suite/serialization/test_serialization_units.jl
+++ b/test/suite/serialization/test_serialization_units.jl
@@ -1,0 +1,288 @@
+module TestSerializationUnits
+
+import Test: Test
+import CTBase.Exceptions: Exceptions
+import CTModels.Components: Components
+import CTModels.Solutions: Solutions
+import CTModels.Serialization: Serialization
+
+include(joinpath("..", "..", "problems", "TestProblems.jl"))
+import .TestProblems
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+function test_serialization_units()
+    Test.@testset "Serialization unit tests" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ==============================================================================
+        # C.1 — _discretize_function / _discretize_dual
+        # ==============================================================================
+
+        Test.@testset "_discretize_function: scalar function" begin
+            f = t -> 2.0 * t
+            T = [0.0, 0.5, 1.0]
+            M = Solutions._discretize_function(f, T, 1)
+            Test.@test M isa Matrix{Float64}
+            Test.@test size(M) == (3, 1)
+            Test.@test M[:, 1] ≈ [0.0, 1.0, 2.0]
+        end
+
+        Test.@testset "_discretize_function: vector function" begin
+            f = t -> [t, 2t]
+            T = [0.0, 0.5, 1.0]
+            M = Solutions._discretize_function(f, T, 2)
+            Test.@test M isa Matrix{Float64}
+            Test.@test size(M) == (3, 2)
+            Test.@test M ≈ [0.0 0.0; 0.5 1.0; 1.0 2.0]
+        end
+
+        Test.@testset "_discretize_function: auto-detect dim (scalar)" begin
+            f = t -> 3.0 * t
+            T = [0.0, 1.0]
+            M = Solutions._discretize_function(f, T)
+            Test.@test size(M) == (2, 1)
+            Test.@test M[2, 1] ≈ 3.0
+        end
+
+        Test.@testset "_discretize_function: auto-detect dim (vector)" begin
+            f = t -> [t, t^2]
+            T = [0.0, 1.0, 2.0]
+            M = Solutions._discretize_function(f, T)
+            Test.@test size(M) == (3, 2)
+            Test.@test M[3, 2] ≈ 4.0
+        end
+
+        Test.@testset "_discretize_dual: nothing passthrough" begin
+            result = Solutions._discretize_dual(nothing, [0.0, 1.0], 2)
+            Test.@test isnothing(result)
+        end
+
+        Test.@testset "_discretize_dual: non-nothing returns matrix" begin
+            f = t -> [t, 1.0 - t]
+            T = [0.0, 0.5, 1.0]
+            M = Solutions._discretize_dual(f, T, 2)
+            Test.@test M isa Matrix{Float64}
+            Test.@test size(M) == (3, 2)
+        end
+
+        # ==============================================================================
+        # C.2 — _serialize_solution: format detection
+        # ==============================================================================
+
+        Test.@testset "_serialize_solution: unified format produces time_grid key" begin
+            _, sol = TestProblems.solution_example()
+            data = Solutions._serialize_solution(sol)
+            Test.@test data isa Dict{String,Any}
+            Test.@test haskey(data, "time_grid")
+            Test.@test !haskey(data, "time_grid_state")
+            Test.@test haskey(data, "state")
+            Test.@test haskey(data, "control")
+            Test.@test haskey(data, "costate")
+            Test.@test haskey(data, "variable")
+            Test.@test haskey(data, "objective")
+            Test.@test haskey(data, "control_interpolation")
+            Test.@test haskey(data, "path_constraints_dual")
+        end
+
+        Test.@testset "_serialize_solution: multi-grid format produces 4 time_grid keys" begin
+            ocp, sol_base = TestProblems.solution_example()
+            T_state = collect(LinRange(0.0, 1.0, 11))
+            T_control = collect(LinRange(0.0, 1.0, 6))
+            T_costate = collect(LinRange(0.0, 1.0, 11))
+            T_path = collect(LinRange(0.0, 1.0, 9))
+            v = Components.variable(sol_base)
+
+            sol_multi = Solutions.build_solution(
+                ocp,
+                T_state,
+                T_control,
+                T_costate,
+                T_path,
+                Components.state(sol_base),
+                Components.control(sol_base),
+                v,
+                Components.costate(sol_base);
+                objective=Solutions.objective(sol_base),
+                iterations=Solutions.iterations(sol_base),
+                constraints_violation=Solutions.constraints_violation(sol_base),
+                message=Solutions.message(sol_base),
+                status=Solutions.status(sol_base),
+                successful=Solutions.successful(sol_base),
+            )
+
+            data = Solutions._serialize_solution(sol_multi)
+            Test.@test haskey(data, "time_grid_state")
+            Test.@test haskey(data, "time_grid_control")
+            Test.@test haskey(data, "time_grid_costate")
+            Test.@test haskey(data, "time_grid_path")
+            Test.@test !haskey(data, "time_grid")
+            Test.@test data["time_grid_state"] ≈ T_state
+            Test.@test data["time_grid_control"] ≈ T_control
+        end
+
+        # ==============================================================================
+        # C.3 — _reconstruct_solution_from_data: unified and multi formats
+        # ==============================================================================
+
+        Test.@testset "_reconstruct_solution_from_data: unified format" begin
+            ocp, sol = TestProblems.solution_example()
+            data = Solutions._serialize_solution(sol)
+            sol2 = Serialization._reconstruct_solution_from_data(ocp, data)
+            Test.@test Solutions.objective(sol2) ≈ Solutions.objective(sol) atol = 1e-10
+            Test.@test Components.time_grid(sol2) ≈ Components.time_grid(sol) atol = 1e-10
+        end
+
+        Test.@testset "_reconstruct_solution_from_data: multi-grid format" begin
+            ocp, sol_base = TestProblems.solution_example()
+            T_state = collect(LinRange(0.0, 1.0, 11))
+            T_control = collect(LinRange(0.0, 1.0, 6))
+            T_costate = collect(LinRange(0.0, 1.0, 11))
+            T_path = collect(LinRange(0.0, 1.0, 9))
+            v = Components.variable(sol_base)
+
+            sol_multi = Solutions.build_solution(
+                ocp,
+                T_state,
+                T_control,
+                T_costate,
+                T_path,
+                Components.state(sol_base),
+                Components.control(sol_base),
+                v,
+                Components.costate(sol_base);
+                objective=Solutions.objective(sol_base),
+                iterations=Solutions.iterations(sol_base),
+                constraints_violation=Solutions.constraints_violation(sol_base),
+                message=Solutions.message(sol_base),
+                status=Solutions.status(sol_base),
+                successful=Solutions.successful(sol_base),
+            )
+
+            data = Solutions._serialize_solution(sol_multi)
+            sol2 = Serialization._reconstruct_solution_from_data(ocp, data)
+            Test.@test Solutions.time_grid_model(sol2) isa Solutions.MultipleTimeGridModel
+            Test.@test Components.time_grid(sol2, :state) ≈ T_state atol = 1e-10
+            Test.@test Components.time_grid(sol2, :control) ≈ T_control atol = 1e-10
+        end
+
+        Test.@testset "_reconstruct_solution_from_data: missing time_grid raises ParsingError" begin
+            ocp, sol = TestProblems.solution_example()
+            data = Solutions._serialize_solution(sol)
+            delete!(data, "time_grid")
+            Test.@test_throws Exceptions.ParsingError Serialization._reconstruct_solution_from_data(
+                ocp, data
+            )
+        end
+
+        Test.@testset "_reconstruct_solution_from_data: missing control_interpolation raises KeyError" begin
+            ocp, sol = TestProblems.solution_example()
+            data = Solutions._serialize_solution(sol)
+            delete!(data, "control_interpolation")
+            Test.@test_throws KeyError Serialization._reconstruct_solution_from_data(
+                ocp, data
+            )
+        end
+
+        # ==============================================================================
+        # C.4 — Pinning du type reconstruit après import
+        # ==============================================================================
+
+        Test.@testset "Reconstructed solution: unified time_grid_model pinning" begin
+            ocp, sol = TestProblems.solution_example()
+            data = Solutions._serialize_solution(sol)
+            sol2 = Serialization._reconstruct_solution_from_data(ocp, data)
+
+            # Unified solution → UnifiedTimeGridModel
+            Test.@test Solutions.time_grid_model(sol2) isa Solutions.UnifiedTimeGridModel
+
+            # Trajectories are callable and consistent at grid points
+            T = Components.time_grid(sol2)
+            x = Components.state(sol2)
+            u = Components.control(sol2)
+            p = Components.costate(sol2)
+            for t in T[1:min(end, 5)]
+                Test.@test x(t) isa AbstractVector
+                Test.@test u(t) isa Union{Number, AbstractVector}
+                Test.@test p(t) isa AbstractVector
+            end
+        end
+
+        Test.@testset "Reconstructed solution: control_interpolation pinning" begin
+            ocp, sol_base = TestProblems.solution_example()
+            T = Components.time_grid(sol_base)
+            x = Components.state(sol_base)
+            u = Components.control(sol_base)
+            p = Components.costate(sol_base)
+            v = Components.variable(sol_base)
+
+            sol_linear = Solutions.build_solution(
+                ocp, Vector{Float64}(T), x, u, v, p;
+                objective=Solutions.objective(sol_base),
+                iterations=Solutions.iterations(sol_base),
+                constraints_violation=Solutions.constraints_violation(sol_base),
+                message=Solutions.message(sol_base),
+                status=Solutions.status(sol_base),
+                successful=Solutions.successful(sol_base),
+                control_interpolation=:linear,
+            )
+
+            data = Solutions._serialize_solution(sol_linear)
+            sol2 = Serialization._reconstruct_solution_from_data(ocp, data)
+            Test.@test Solutions.control_interpolation(sol2) == :linear
+        end
+
+        # ==============================================================================
+        # C.5 — Round-trip des duals issus de DualSlice / BoxDualDiff
+        # ==============================================================================
+
+        Test.@testset "Round-trip: duals from DualSlice/BoxDualDiff (JSON)" begin
+            ocp, sol = TestProblems.solution_example_dual()
+
+            # Access a path dual via dual() — returns a DualSlice functor
+            pcd = Solutions.path_constraints_dual(sol)
+            Test.@test !isnothing(pcd)
+
+            # Export and re-import
+            Serialization.export_ocp_solution(sol; filename="dual_functor_test", format=:JSON)
+            sol2 = Serialization.import_ocp_solution(
+                ocp; filename="dual_functor_test", format=:JSON
+            )
+
+            # Duals survive the round-trip
+            pcd2 = Solutions.path_constraints_dual(sol2)
+            Test.@test !isnothing(pcd2)
+            T = Components.time_grid(sol)
+            for t in T[1:min(end, 3)]
+                Test.@test pcd2(t) ≈ pcd(t) atol = 1e-8
+            end
+
+            isfile("dual_functor_test.json") && rm("dual_functor_test.json")
+        end
+
+        Test.@testset "Round-trip: duals from DualSlice/BoxDualDiff (JLD2)" begin
+            ocp, sol = TestProblems.solution_example_dual()
+            pcd = Solutions.path_constraints_dual(sol)
+
+            Serialization.export_ocp_solution(sol; filename="dual_functor_jld_test", format=:JLD)
+            sol2 = Serialization.import_ocp_solution(
+                ocp; filename="dual_functor_jld_test", format=:JLD
+            )
+
+            pcd2 = Solutions.path_constraints_dual(sol2)
+            Test.@test !isnothing(pcd2)
+            T = Components.time_grid(sol)
+            for t in T[1:min(end, 3)]
+                Test.@test pcd2(t) ≈ pcd(t) atol = 1e-8
+            end
+
+            isfile("dual_functor_jld_test.jld2") && rm("dual_functor_jld_test.jld2")
+        end
+
+    end
+end
+
+end # module
+
+# CRITICAL: Redefine in outer scope for TestRunner
+test_serialization_units() = TestSerializationUnits.test_serialization_units()


### PR DESCRIPTION
## Summary

This PR simplifies the solution reconstruction logic in the serialization module by removing optional arguments and reading all required data directly from the imported dictionary.

## Changes

- **Simplified `_reconstruct_solution_from_data`**: All duals and `control_interpolation` are now read directly from the `data` dictionary instead of being passed as optional arguments
- **Removed legacy compatibility**: Dropped support for the legacy `time_grid_dual` key name (now requires `time_grid_path`)
- **Updated tests**: Modified existing tests to use the new unified API
- **Added unit tests**: Created `test_serialization_units.jl` with focused unit tests for serialization helpers
- **Improved documentation**: Updated docstrings to reflect the new simplified API

## Motivation

The previous API had many optional arguments that made the function signature complex and error-prone. By requiring all data to be present in the imported dictionary, the API is cleaner and more maintainable. The legacy `time_grid_dual` key was only needed for backward compatibility with very old exports and can now be safely removed.

## Testing

- All existing serialization tests updated and passing
- New unit tests added for `_discretize_function`, `_discretize_dual`, `_serialize_solution`, and `_reconstruct_solution_from_data`
- Round-trip tests verified for both JSON and JLD2 formats