### PR TITLE
Adopt CTBase.Traits time-dependence types (phase B)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,4 +46,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Random", "Test"]
+test = ["Aqua", "JLD2", "JSON3", "Plots", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.12.0-beta"
+version = "0.13.0-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -25,7 +25,7 @@ CTModelsPlots = "Plots"
 
 [compat]
 Aqua = "0.8"
-CTBase = "0.21"
+CTBase = "0.22"
 DocStringExtensions = "0.9"
 JLD2 = "0.6"
 JSON3 = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -46,4 +46,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "JLD2", "JSON3", "Plots", "Random", "Test"]
+test = ["Aqua", "Random", "Test"]

--- a/src/Components/Components.jl
+++ b/src/Components/Components.jl
@@ -28,6 +28,7 @@ module Components
 
 import CTBase.Core
 import CTBase.Exceptions
+import CTBase.Traits: TimeDependence, Autonomous, NonAutonomous
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using OrderedCollections: OrderedCollections
 

--- a/src/Components/types.jl
+++ b/src/Components/types.jl
@@ -4,45 +4,9 @@
 #  constraints, definitions)
 # ------------------------------------------------------------------------------ #
 
-"""
-$(TYPEDEF)
-
-Abstract base type representing time dependence of an optimal control problem.
-
-Used as a type parameter to distinguish between autonomous and non-autonomous
-systems at the type level, enabling dispatch and compile-time optimisations.
-
-See also: [`CTModels.Components.Autonomous`](@ref), [`CTModels.Components.NonAutonomous`](@ref),
-[`CTModels.Components.TimesModel`](@ref).
-"""
-abstract type TimeDependence end
-
-"""
-$(TYPEDEF)
-
-Type tag indicating that the dynamics and other functions of an optimal control
-problem do not explicitly depend on time.
-
-For autonomous systems, the dynamics have the form `ẋ = f(x, u)` rather than
-`ẋ = f(t, x, u)`.
-
-See also: [`CTModels.Components.TimeDependence`](@ref), [`CTModels.Components.NonAutonomous`](@ref),
-[`CTModels.Components.TimesModel`](@ref).
-"""
-abstract type Autonomous<:TimeDependence end
-
-"""
-$(TYPEDEF)
-
-Type tag indicating that the dynamics and other functions of an optimal control
-problem explicitly depend on time.
-
-For non-autonomous systems, the dynamics have the form `ẋ = f(t, x, u)`.
-
-See also: [`CTModels.Components.TimeDependence`](@ref), [`CTModels.Components.Autonomous`](@ref),
-[`CTModels.Components.TimesModel`](@ref).
-"""
-abstract type NonAutonomous<:TimeDependence end
+# TimeDependence / Autonomous / NonAutonomous are now defined in `CTBase.Traits`
+# and imported into this module (see Components.jl). They remain exported from
+# `CTModels.Components` for backward compatibility.
 
 # ------------------------------------------------------------------------------ #
 """

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -32,6 +32,10 @@ module Models
 
 import CTBase.Core
 import CTBase.Exceptions
+import CTBase.Traits
+# Time/variable-dependence predicates are generic functions owned by CTBase.Traits;
+# CTModels only provides the `Model` trait contract (see model.jl) and re-exports them.
+import CTBase.Traits: is_autonomous, is_nonautonomous, is_variable, is_nonvariable, has_variable
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
 using ..Components

--- a/src/Models/model.jl
+++ b/src/Models/model.jl
@@ -95,82 +95,28 @@ end
 # Getters — time dependence
 # ------------------------------------------------------------------------------ #
 
-"""
-$(TYPEDSIGNATURES)
+# ------------------------------------------------------------------------------ #
+# Trait contract — time & variable dependence
+#
+# CTModels no longer defines the boolean predicates `is_autonomous`,
+# `is_nonautonomous`, `is_variable`, `is_nonvariable`, `has_variable`: these are
+# generic functions owned by `CTBase.Traits`. A `Model` only declares that it has
+# the traits and reports the trait values; the predicates then follow generically.
+#
+# - time dependence is read from the `TD` type parameter,
+# - variable dependence is read from the *type* of the variable model
+#   (`EmptyVariableModel` ⟹ Fixed, any other ⟹ NonFixed) — not from the dimension.
+# ------------------------------------------------------------------------------ #
 
-Return `true` for an autonomous model.
+Traits.has_time_dependence_trait(::Model) = true
 
-# Arguments
-- `::Model{Autonomous,...}`: An autonomous model.
+Traits.time_dependence(::Model{TD}) where {TD} = TD
 
-# Returns
-- `Bool`: `true`.
+Traits.has_variable_dependence_trait(::Model) = true
 
-See also: [`CTModels.Models.is_nonautonomous`](@ref).
-"""
-function is_autonomous(
-    ::Model{
-        Autonomous,
-        <:TimesModel,
-        <:AbstractStateModel,
-        <:AbstractControlModel,
-        <:AbstractVariableModel,
-        <:Function,
-        <:AbstractObjectiveModel,
-        <:AbstractConstraintsModel,
-        <:AbstractDefinition,
-        <:Union{Function,Nothing},
-    },
-)
-    return true
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Return `false` for a non-autonomous model.
-
-# Arguments
-- `::Model{NonAutonomous,...}`: A non-autonomous model.
-
-# Returns
-- `Bool`: `false`.
-
-See also: [`CTModels.Models.is_autonomous`](@ref).
-"""
-function is_autonomous(
-    ::Model{
-        NonAutonomous,
-        <:TimesModel,
-        <:AbstractStateModel,
-        <:AbstractControlModel,
-        <:AbstractVariableModel,
-        <:Function,
-        <:AbstractObjectiveModel,
-        <:AbstractConstraintsModel,
-        <:AbstractDefinition,
-        <:Union{Function,Nothing},
-    },
-)
-    return false
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Check whether the problem has optimisation variables.
-
-# Arguments
-- `ocp::Model`: The optimal control problem.
-
-# Returns
-- `Bool`: `true` if the problem has optimisation variables, `false` otherwise.
-
-See also: [`CTModels.Models.is_nonvariable`](@ref), [`CTModels.Models.variable_dimension`](@ref).
-"""
-function is_variable(ocp::Model)::Bool
-    return variable_dimension(ocp) > 0
-end
+Traits.variable_dependence(ocp::Model) = _variable_dependence(ocp.variable)
+_variable_dependence(::EmptyVariableModel) = Traits.Fixed
+_variable_dependence(::AbstractVariableModel) = Traits.NonFixed
 
 """
 $(TYPEDSIGNATURES)
@@ -188,21 +134,6 @@ See also: [`CTModels.Models.has_control`](@ref), [`CTModels.Models.control_dimen
 function is_control_free(ocp::Model)::Bool
     return control_dimension(ocp) == 0
 end
-
-"""
-$(TYPEDSIGNATURES)
-
-Check whether the problem has optimisation variables.
-
-# Arguments
-- `ocp::Model`: The optimal control problem.
-
-# Returns
-- `Bool`: `true` if the problem has optimisation variables, `false` otherwise.
-
-See also: [`CTModels.Models.is_variable`](@ref).
-"""
-has_variable(ocp::Model)::Bool = is_variable(ocp)
 
 """
 $(TYPEDSIGNATURES)
@@ -248,36 +179,6 @@ Check whether the problem is abstractly defined.
 See also: [`CTModels.Models.has_abstract_definition`](@ref).
 """
 is_abstractly_defined(ocp::Model)::Bool = has_abstract_definition(ocp)
-
-"""
-$(TYPEDSIGNATURES)
-
-Check whether the problem is non-autonomous (time-dependent).
-
-# Arguments
-- `ocp::Model`: The optimal control problem.
-
-# Returns
-- `Bool`: `true` if the problem is non-autonomous, `false` otherwise.
-
-See also: [`CTModels.Models.is_autonomous`](@ref).
-"""
-is_nonautonomous(ocp::Model)::Bool = !is_autonomous(ocp)
-
-"""
-$(TYPEDSIGNATURES)
-
-Check whether the problem has no optimisation variables.
-
-# Arguments
-- `ocp::Model`: The optimal control problem.
-
-# Returns
-- `Bool`: `true` if the problem has no optimisation variables, `false` otherwise.
-
-See also: [`CTModels.Models.is_variable`](@ref).
-"""
-is_nonvariable(ocp::Model)::Bool = !is_variable(ocp)
 
 # ------------------------------------------------------------------------------ #
 # Getters — State


### PR DESCRIPTION
## Summary

Migrates CTModels to consume the trait system from **`CTBase.Traits`** (phase B of
the CTFlows → CTBase move).

- `Components`: `TimeDependence` / `Autonomous` / `NonAutonomous` are no longer
  defined here — they are imported from `CTBase.Traits` (still re-exported from
  `CTModels.Components` for backward compatibility). After this, there is a single
  set of these types across the ecosystem.
- `Models`: drops the boolean predicates `is_autonomous`, `is_nonautonomous`,
  `is_variable`, `is_nonvariable`, `has_variable`. A `Model` now only implements
  the **trait contract**, and the predicates follow generically from
  `CTBase.Traits`:
  - `time_dependence(::Model{TD}) = TD`
  - `variable_dependence(ocp)` dispatches on the **type** of the variable model
    (`EmptyVariableModel ⟹ Fixed`, otherwise `NonFixed`) — not on the dimension.
  The predicates are re-exported for backward compatibility (`CTModels.is_variable`
  etc. keep working). `is_control_free` / `has_control` are unchanged.

Bumps version to `0.13.0-beta`, requires `CTBase 0.22`.

## Cross-repo ordering (IMPORTANT)

1. **CTBase.jl#461** must merge first and ship a `0.22` beta.
2. **This PR** then goes green → release `0.13` beta.
3. **CTFlows** consumes both.

## Notes

- The only observable behaviour change is that variable dependence is now derived
  from the variable-model **type** rather than `variable_dimension(ocp) > 0`. These
  agree as long as a `VariableModel`/`VariableModelSolution` always has dimension
  `> 0` (the build produces `EmptyVariableModel` when there is no variable) — the
  full CTModels suite is green, confirming the invariant holds.

## Test plan

- [x] Full CTModels suite green against locally `dev`-ed CTBase 0.22.
- [x] `CTModels.Components.Autonomous === CTBase.Traits.Autonomous`.
- [ ] CI green once CTBase 0.22 is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)