### PR TITLE
Phase C: widen CTBase compat to 0.23

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.13.0-beta"
+version = "0.13.1-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -25,7 +25,7 @@ CTModelsPlots = "Plots"
 
 [compat]
 Aqua = "0.8"
-CTBase = "0.22"
+CTBase = "0.22, 0.23"
 DocStringExtensions = "0.9"
 JLD2 = "0.6"
 JSON3 = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ CTModelsPlots = "Plots"
 
 [compat]
 Aqua = "0.8"
-CTBase = "0.22, 0.23"
+CTBase = "0.23"
 DocStringExtensions = "0.9"
 JLD2 = "0.6"
 JSON3 = "1"


### PR DESCRIPTION
## Summary

- Widens `CTBase` compat from `"0.22"` to `"0.22, 0.23"` to allow CTBase 0.23 (which adds `CTBase.Data`)
- Bumps version to `0.13.1-beta`
- No code change — CTModels does not consume `CTBase.Data` directly

Part of the CTFlows → CTBase move project (phase C).

## Test plan

- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)