### PR TITLE
chore: widen CTBase compat to 0.24, 0.25 (0.13.3-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3-beta] - 2026-06-26
+
+### 📦 Dependencies
+
+- Widen CTBase compat to `0.24, 0.25` (CTBase 0.25 moves `NotProvided`/`NotProvidedType` to `CTBase.Core`; CTModels has no source change).
+
 ## [0.13.2-beta] - 2026-06-25
 
 ### 📦 Dependencies

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.13.2-beta"
+version = "0.13.3-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -25,7 +25,7 @@ CTModelsPlots = "Plots"
 
 [compat]
 Aqua = "0.8"
-CTBase = "0.24"
+CTBase = "0.24, 0.25"
 DocStringExtensions = "0.9"
 JLD2 = "0.6"
 JSON3 = "1"


### PR DESCRIPTION
## Summary

Widen `CTBase` compat to `0.24, 0.25`. CTBase 0.25 moves `NotProvided`/`NotProvidedType` to `CTBase.Core`; CTModels does not depend on those names, so this is a compat-only change (no source edits).

Needed so CTFlows can resolve CTBase 0.25 alongside CTModels.

## Test plan

- [x] Full CTModels suite green against dev-linked CTBase 0.25.0-beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)