### PR TITLE
test: freeze plotting reference matrix + free-final-time fixture

### DIFF
--- a/test/problems/TestProblems.jl
+++ b/test/problems/TestProblems.jl
@@ -4,6 +4,7 @@ using CTModels
 include("solution_example.jl")
 include("beam.jl")
 include("solution_example_dual.jl")
+include("solution_example_free_final_time.jl")
 
 # From solution_example.jl
 export solution_example
@@ -13,4 +14,7 @@ export Beam
 
 # From solution_example_dual.jl
 export solution_example_dual
+
+# From solution_example_free_final_time.jl
+export solution_example_free_final_time
 end

--- a/test/problems/solution_example_free_final_time.jl
+++ b/test/problems/solution_example_free_final_time.jl
@@ -1,0 +1,131 @@
+"""
+Free-final-time fixture: the double integrator in minimum time.
+
+Mirrors the OptimalControl tutorial
+(https://control-toolbox.org/Tutorials.jl/stable/tutorial-free-times-final.html)
+and is built with the functional CTModels API (variable! before time!(...; indf=…),
+see https://control-toolbox.org/OptimalControl.jl/stable/manual-macro-free.html).
+
+Problem (DSL form kept for printing only):
+
+    tf ∈ R, variable
+    t ∈ [0, tf], time
+    x = (q, v) ∈ R², state
+    u ∈ R, control
+    -1 ≤ u(t) ≤ 1
+    0.05 ≤ tf
+    x(0) == [0, 0]
+    x(tf) == [1, 0]
+    ẋ(t) == [x₂(t), u(t)]
+    tf → min
+
+Analytical (bang-bang) solution, switch at t₁ = 1, optimal tf = 2:
+
+    x₁(t) = t²/2                on [0,1),   -t²/2 + 2t - 1  on [1,2]
+    x₂(t) = t                   on [0,1),    2 - t          on [1,2]
+    u(t)  = +1                  on [0,1),   -1              on [1,2]
+    p₁(t) = 1,  p₂(t) = 1 - t
+
+The point of this fixture for the plot suite: `tf` is a decision variable, so the
+time decorations (vertical lines at t0/tf) read the final time from the variable via
+`final_time(model, variable(sol))` — a path no fixed-time fixture exercises.
+"""
+function solution_example_free_final_time()
+    t0 = 0.0
+    x0 = [0.0, 0.0]
+    xf = [1.0, 0.0]
+    tf_opt = 2.0
+
+    # ---- model (functional API) ------------------------------------------------
+    pre_ocp = CTModels.PreModel()
+
+    # variable first: variable[1] holds the free final time
+    CTModels.variable!(pre_ocp, 1, "tf")
+
+    # free final time: tf = variable[1]
+    CTModels.time!(pre_ocp; t0=t0, indf=1)
+
+    CTModels.state!(pre_ocp, 2, "x", ["q", "v"])
+    CTModels.control!(pre_ocp, 1)
+
+    # dynamics: ẋ(t) == [x₂(t), u(t)]
+    dynamics!(r, t, x, u, v) = begin
+        r[1] = x[2]
+        r[2] = u[1]
+        return nothing
+    end
+    CTModels.dynamics!(pre_ocp, dynamics!)
+
+    # objective: minimise tf = v[1]
+    mayer(x0_, xf_, v) = v[1]
+    CTModels.objective!(pre_ocp, :min; mayer=mayer)
+
+    # control box constraint: -1 ≤ u(t) ≤ 1
+    CTModels.constraint!(
+        pre_ocp, :control; rg=1:1, lb=[-1.0], ub=[1.0], label=:u_box
+    )
+
+    # variable box constraint: 0.05 ≤ tf ≤ Inf
+    CTModels.constraint!(
+        pre_ocp, :variable; rg=1:1, lb=[0.05], ub=[Inf], label=:tf_box
+    )
+
+    # boundary constraints: x(t0) == x0 and x(tf) == xf
+    f_boundary(r, x0_state, xf_state, v) = begin
+        r[1] = x0_state[1] - x0[1]
+        r[2] = x0_state[2] - x0[2]
+        r[3] = xf_state[1] - xf[1]
+        r[4] = xf_state[2] - xf[2]
+        return nothing
+    end
+    CTModels.constraint!(
+        pre_ocp, :boundary; f=f_boundary, lb=zeros(4), ub=zeros(4), label=:endpoints
+    )
+
+    # DSL-style definition, for printing only
+    definition = quote
+        tf ∈ R, variable
+        t ∈ [0, tf], time
+        x = (q, v) ∈ R², state
+        u ∈ R, control
+        -1 ≤ u(t) ≤ 1
+        0.05 ≤ tf
+        x(0) == [0, 0]
+        x(tf) == [1, 0]
+        ẋ(t) == [x₂(t), u(t)]
+        tf → min
+    end
+    CTModels.definition!(pre_ocp, definition)
+
+    CTModels.time_dependence!(pre_ocp; autonomous=true)
+
+    ocp = CTModels.build(pre_ocp)
+
+    # ---- solution (closed form) ------------------------------------------------
+    x1(t) = t < 1 ? t^2 / 2 : -t^2 / 2 + 2t - 1
+    x2(t) = t < 1 ? t : 2 - t
+    x(t) = [x1(t), x2(t)]
+    u(t) = [t < 1 ? 1.0 : -1.0]
+    p(t) = [1.0, 1.0 - t]
+
+    v = [tf_opt]
+    objective = tf_opt
+
+    times = Vector{Float64}(range(t0, tf_opt, 201))
+    sol = CTModels.build_solution(
+        ocp,
+        times,
+        x,
+        u,
+        v,
+        p;
+        objective=objective,
+        iterations=-1,
+        constraints_violation=0.0,
+        message="",
+        status=:optimal,
+        successful=true,
+    )
+
+    return ocp, sol
+end

--- a/test/suite/extensions/test_plot_reference.jl
+++ b/test/suite/extensions/test_plot_reference.jl
@@ -1,0 +1,220 @@
+module TestPlotReference
+
+# ==============================================================================
+# Reference matrix for the plotting extension — behaviour freeze.
+#
+# This file turns the hand-written visual-check scripts under `.extras/`
+# (`plot_duals.jl`, `plot_manual.jl`, `plot_series.jl`) into executable,
+# assertion-based tests so the reference matrix runs in CI. It deliberately
+# covers only what `test_plot.jl` does NOT already assert:
+#   - description-symbol subsets: plot(sol, :state, :control, :path), …
+#   - end-to-end per-group `*_style=:none`
+#   - end-to-end decoration disabling (`time_style`, `*_bounds_style`)
+#   - user style NamedTuples + `color`/`label` keywords
+#   - two-solution comparison overlay (`plot!`)
+#
+# Freeze granularity is behavioural (`isa Plots.Plot` / no throw): the scripts
+# themselves only checked "does it render". Golden assertions on the figure IR
+# come with the CTBase engine migration (see .reports/dev report, phase 1/3).
+#
+# Fixtures (reused, no new problem introduced):
+#   - solution_example()      → 2 states / 1 control, matrices (constant
+#     interpolation) with a distinct costate grid `T[1:end-1]`, path constraint
+#     in the model but no duals — mirrors `.extras/plot_manual.jl`.
+#   - solution_example_dual() → the exact OCP of `.extras/plot_duals.jl`
+#     (1 state / 1 control, path constraints + duals).
+#   - solution_example_free_final_time() → double integrator in minimum time,
+#     `tf` free (decision variable) — mirrors `.extras/plot_variable.jl` without
+#     a CTDirect/Ipopt dependency (closed-form solution via `build_solution`).
+# ==============================================================================
+
+import Test: Test
+import CTBase.Exceptions: Exceptions
+import Plots: Plots
+import CTModels: CTModels
+
+include(joinpath("..", "..", "problems", "TestProblems.jl"))
+import .TestProblems
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+function test_plot_reference()
+    Test.@testset "Plotting reference matrix" verbose = VERBOSE showtiming = SHOWTIMING begin
+
+        # solution_example: matrices / distinct costate grid (plot_manual.jl)
+        _, sol, _ = TestProblems.solution_example()
+        # solution_example_dual: the plot_duals.jl model, with duals
+        _, sol_pc = TestProblems.solution_example_dual()
+        # free final time: tf is a decision variable (plot_variable.jl)
+        ocp_tf, sol_tf = TestProblems.solution_example_free_final_time()
+
+        # ======================================================================
+        # Description-symbol subsets (.extras/plot_duals.jl:70-78)
+        # Every subset must render for a solution carrying path constraints and
+        # duals. `plot(sol)` with no description falls back to "everything".
+        # ======================================================================
+        Test.@testset "description subsets" begin
+            Test.@test Plots.plot(sol_pc) isa Plots.Plot
+            for desc in (
+                (:state,),
+                (:state, :costate),
+                (:state, :control),
+                (:state, :control, :path),
+                (:costate,),
+                (:control,),
+                (:path,),
+                (:dual,),
+                (:path, :dual),
+            )
+                Test.@test Plots.plot(sol_pc, desc...) isa Plots.Plot
+                Test.@test Plots.plot(sol_pc, desc...; layout=:group) isa Plots.Plot
+            end
+        end
+
+        # ======================================================================
+        # Per-group styles set to :none, end to end (.extras/plot_duals.jl:80-90)
+        # `do_plot` booleans are already unit-tested; here we assert the full
+        # pipeline still returns a valid figure when a group is dropped.
+        # ======================================================================
+        Test.@testset "group style :none renders" begin
+            for kw in (
+                (; state_style=:none),
+                (; costate_style=:none),
+                (; control_style=:none),
+                (; path_style=:none),
+                (; dual_style=:none),
+                (; state_style=:none, control_style=:none),
+                (; state_style=:none, costate_style=:none),
+                (; costate_style=:none, control_style=:none),
+                (; path_style=:none, control_style=:none),
+                (; dual_style=:none, control_style=:none),
+            )
+                Test.@test Plots.plot(sol_pc; layout=:split, kw...) isa Plots.Plot
+            end
+        end
+
+        # ======================================================================
+        # Decorations disabled, end to end (.extras/plot_duals.jl:92-115)
+        # ======================================================================
+        Test.@testset "decorations disabled render" begin
+            for kw in (
+                (; time_style=:none, label="toto"),
+                (; state_bounds_style=:none),
+                (; control_bounds_style=:none),
+                (; path_bounds_style=:none),
+                (; state_bounds_style=:none, control_bounds_style=:none),
+                (; state_bounds_style=:none, path_bounds_style=:none),
+                (; control_bounds_style=:none, path_bounds_style=:none),
+                (;
+                    state_bounds_style=:none,
+                    control_bounds_style=:none,
+                    path_bounds_style=:none,
+                ),
+                (; time_style=:none, state_bounds_style=:none),
+                (; time_style=:none, control_bounds_style=:none),
+                (; time_style=:none, control_bounds_style=:none, path_bounds_style=:none),
+            )
+                Test.@test Plots.plot(sol_pc; layout=:split, kw...) isa Plots.Plot
+            end
+        end
+
+        # ======================================================================
+        # User style NamedTuples + color/label (.extras/plot_manual.jl:201-225)
+        # ======================================================================
+        Test.@testset "user styles and keywords" begin
+            dash = (linestyle=:dash, linewidth=1)
+            Test.@test Plots.plot(sol; label="tata", color=2) isa Plots.Plot
+            Test.@test Plots.plot(sol; state_style=dash) isa Plots.Plot
+            Test.@test Plots.plot(sol; costate_style=dash) isa Plots.Plot
+            Test.@test Plots.plot(sol; control_style=dash) isa Plots.Plot
+            Test.@test Plots.plot(
+                sol; state_style=dash, control_style=(dash..., seriestype=:path)
+            ) isa Plots.Plot
+            Test.@test Plots.plot(sol; state_style=dash, costate_style=dash) isa Plots.Plot
+            Test.@test Plots.plot(sol; costate_style=dash, control_style=dash) isa
+                Plots.Plot
+            Test.@test Plots.plot(
+                sol; state_style=:none, costate_style=dash, control_style=dash
+            ) isa Plots.Plot
+        end
+
+        # ======================================================================
+        # control=:all / :norm with description subsets, both layouts
+        # (.extras/plot_manual.jl:163-190)
+        # ======================================================================
+        Test.@testset "control mode × description × layout" begin
+            for layout in (:group, :split)
+                Test.@test Plots.plot(sol; layout=layout, control=:components) isa
+                    Plots.Plot
+                Test.@test Plots.plot(sol; layout=layout, control=:norm) isa Plots.Plot
+                Test.@test Plots.plot(sol; layout=layout, control=:all) isa Plots.Plot
+                Test.@test Plots.plot(sol, :control; layout=layout, control=:norm) isa
+                    Plots.Plot
+                Test.@test Plots.plot(sol, :control; layout=layout, control=:all) isa
+                    Plots.Plot
+                Test.@test Plots.plot(
+                    sol, :state, :control; layout=layout, control=:all
+                ) isa Plots.Plot
+            end
+        end
+
+        # ======================================================================
+        # Two-solution comparison overlay (.extras/plot_manual.jl:228-239)
+        # First solution sets size + normalized time; the second overlays with
+        # per-group dashed styles. This is the R1 case (plot! reuse semantics).
+        # ======================================================================
+        Test.@testset "two-solution comparison overlay" begin
+            plt = Plots.plot(sol; color=15, size=(700, 450), time=:normalise, label="sol1")
+            Test.@test plt isa Plots.Plot
+            style = (linestyle=:dash,)
+            Test.@test Plots.plot!(
+                plt,
+                sol;
+                color=1,
+                time=:normalise,
+                label="sol2",
+                state_style=style,
+                costate_style=style,
+                control_style=style,
+            ) isa Plots.Plot
+        end
+
+        # ======================================================================
+        # plot! reuse against a pre-sized / current figure
+        # (.extras/plot_manual.jl:153-159)
+        # ======================================================================
+        Test.@testset "plot! onto pre-sized and current figures" begin
+            Plots.plot(; size=(800, 800))
+            Test.@test Plots.plot!(sol; color=2) isa Plots.Plot
+
+            plt = Plots.plot(; size=(800, 800))
+            Test.@test Plots.plot!(plt, sol) isa Plots.Plot
+        end
+
+        # ======================================================================
+        # Free final time (.extras/plot_variable.jl): tf is a decision variable,
+        # so the time decorations read tf from the variable via
+        # `final_time(model, variable(sol))`. This is the only path here that no
+        # fixed-time fixture exercises. Covered for both real and normalized time.
+        # ======================================================================
+        Test.@testset "free final time decorations" begin
+            # guard: the fixture is genuinely free-final-time, tf = 2
+            Test.@test !CTModels.has_fixed_final_time(ocp_tf)
+            Test.@test CTModels.final_time(ocp_tf, CTModels.variable(sol_tf)) ≈ 2.0
+
+            Test.@test Plots.plot(sol_tf) isa Plots.Plot
+            Test.@test Plots.plot(sol_tf; layout=:group) isa Plots.Plot
+            Test.@test Plots.plot(sol_tf; time=:normalize) isa Plots.Plot
+            Test.@test Plots.plot(sol_tf, :state, :control) isa Plots.Plot
+            # time decoration explicitly on vs off
+            Test.@test Plots.plot(sol_tf; time_style=(color=:red,)) isa Plots.Plot
+            Test.@test Plots.plot(sol_tf; time_style=:none) isa Plots.Plot
+        end
+    end
+end
+
+end # module
+
+# CRITICAL: Redefine in outer scope for TestRunner
+test_plot_reference() = TestPlotReference.test_plot_reference()


### PR DESCRIPTION
## Summary

Transcribe the `.extras/` visual-check scripts into an executable reference matrix that freezes the plotting behaviour for phase 0 (spec & gel) of the plotting-engine unification. Two components:

1. **test_plot_reference.jl** (72 assertions) — covers the gaps left by test_plot.jl:
   - description-symbol subsets (plot(sol, :state, :control, :path) …)
   - per-group `*_style=:none` end-to-end (5 groups + combos)
   - decoration disabling (`time_style`, `*_bounds_style` …)
   - user styles (color/label, NamedTuple per group)
   - `plot!` overlays + normalized time
   - free-final-time decoration path (new fixture)

2. **solution_example_free_final_time** — new fixture, double integrator minimum time:
   - free final time (`tf` is a decision variable)
   - built via functional CTModels API (variable! before time!(...; indf=1))
   - closed-form solution via build_solution (no CTDirect/Ipopt dependency)
   - exercises the `final_time(model, variable(sol))` path that no fixed-time fixture covers

## Test Results

- test_plot_reference.jl: **72/72** ✅
- extensions/ total (with existing test_plot.jl): **203/203** ✅  
- Full CTModels suite (Aqua included): **passed** ✅

## Impact

Non-breaking change to test/ only. The reference matrix is the foundation for phase 1 (CTBase engine + CTBasePlots renderer): golden assertions on the IR will be added when that phase begins.

🤖 Generated with Claude Code