### PR TITLE
fix(models): AD-differentiable constraint-by-label functors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.2-beta] - 2026-07-10
+
+### 🐛 Bug Fixes
+
+#### **Models** — constraint-by-label functors are AD-differentiable
+
+- **`SubPathConstraint` and `SubBoundaryConstraint` now allocate their intermediate buffer
+  with `eltype(r)`** (the caller's buffer element type) instead of a hard-coded `Float64`
+  vector. Combined with the CTBase `to_out_of_place` fix (≥ 0.27.4-beta), the out-of-place
+  functor returned by `Models.constraint(model, label)` for a `:path`/`:boundary` constraint
+  can now be differentiated through (e.g. `ForwardDiff.Dual` inputs), which previously threw
+  `MethodError: Float64(::Dual)`.
+- **Why**: needed to differentiate a path constraint referenced by label through a
+  constrained CTFlows `:total` Hamiltonian flow.
+- **No breaking changes**: purely additive; behaviour on `Float64` buffers is unchanged.
+  See [BREAKING.md](BREAKING.md).
+
 ## [0.15.1-beta] - 2026-07-09
 
 ### ✨ New Features

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.15.1-beta"
+version = "0.15.2-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/src/Models/constraint_functors.jl
+++ b/src/Models/constraint_functors.jl
@@ -20,7 +20,9 @@ struct SubPathConstraint{CP,I} <: Function
 end
 
 function (f::SubPathConstraint)(r, t, x, u, v)
-    r_ = zeros(f.n)
+    # Match the caller's buffer element type so the intermediate buffer can hold
+    # e.g. ForwardDiff.Dual values when the constraint is differentiated through.
+    r_ = zeros(eltype(r), f.n)
     f.cp[2](r_, t, x, u, v)
     r .= r_[f.indices]
     return nothing
@@ -56,7 +58,9 @@ struct SubBoundaryConstraint{CP,I} <: Function
 end
 
 function (f::SubBoundaryConstraint)(r, x0, xf, v)
-    r_ = zeros(f.n)
+    # Match the caller's buffer element type so the intermediate buffer can hold
+    # e.g. ForwardDiff.Dual values when the constraint is differentiated through.
+    r_ = zeros(eltype(r), f.n)
     f.cp[2](r_, x0, xf, v)
     r .= r_[f.indices]
     return nothing

--- a/test/suite/models/test_model.jl
+++ b/test/suite/models/test_model.jl
@@ -180,6 +180,21 @@ function test_model()
         Test.@test Models.constraint(model, :control_scalar_2)[2](t, x, u, v) == u[2]
         Test.@test Models.constraint(model, :variable_scalar_2)[2](x0, xf, v) == v[2]
 
+        # Regression: resolved constraint functors must widen their buffer element type
+        # from the arguments (they were Float64-only, which breaks differentiation of a
+        # constraint through AD). Complex arguments are a dependency-free proxy for a
+        # non-Float64 numeric type — `Float64(z)` with a nonzero imaginary part throws.
+        Test.@testset "constraint-by-label — buffer widens to non-Float64 eltype" begin
+            xc = ComplexF64[2 + im, 3 + 2im]
+            resp = Models.constraint(model, :path)[2](t, xc, u, v)
+            Test.@test resp == xc .+ u .+ v .+ t
+            Test.@test eltype(resp) <: Complex
+            x0c = ComplexF64[1 + im, 2 - im]
+            resb = Models.constraint(model, :boundary)[2](x0c, xf, v)
+            Test.@test resb == x0c .+ v .* (xf .- x0c)
+            Test.@test eltype(resb) <: Complex
+        end
+
         # test the type of the constraints
         Test.@test Models.constraint(model, :path)[1] == :path
         Test.@test Models.constraint(model, :boundary)[1] == :boundary


### PR DESCRIPTION
## Summary

`SubPathConstraint` / `SubBoundaryConstraint` allocated their intermediate buffer as a hard-coded `Float64` vector, so the out-of-place functor from `Models.constraint(model, label)` for a `:path`/`:boundary` constraint threw `MethodError: Float64(::Dual)` when differentiated through.

- Both now allocate the intermediate buffer with `eltype(r)` (the caller's buffer type). Combined with the CTBase `to_out_of_place` fix, the resolved functor is now differentiable (e.g. `ForwardDiff.Dual` inputs).
- Added a dependency-free regression test in `test_model.jl` using `ComplexF64` as a proxy for a non-`Float64` numeric type (`Float64(z)` with a nonzero imaginary part throws).

## Release / coordination

Part of a 3-package coordinated change. Requires **CTBase ≥ 0.27.4-beta** (control-toolbox/CTBase.jl#486). Register **after** that CTBase beta and **before** CTFlows `0.11.0-beta`. Version bumped to `0.15.2-beta`. No breaking changes (purely additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)