### PR TITLE
fix(types): repeat struct bounds in where-clauses to stop silent widening to Any

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -2,6 +2,7 @@
 locale = "en"
 extend-ignore-re = [
     "ser",
+    "mis-",
 ]
 
 [files]

--- a/src/Components/constraints_accessors.jl
+++ b/src/Components/constraints_accessors.jl
@@ -32,7 +32,7 @@ See also: [`CTModels.Components.boundary_constraints_nl`](@ref), [`CTModels.Comp
 """
 function path_constraints_nl(
     model::ConstraintsModel{TP,<:Tuple,<:Tuple,<:Tuple,<:Tuple}
-) where {TP}
+) where {TP<:Tuple}
     return model.path_nl
 end
 
@@ -48,7 +48,7 @@ See also: [`CTModels.Components.path_constraints_nl`](@ref), [`CTModels.Componen
 """
 function boundary_constraints_nl(
     model::ConstraintsModel{<:Tuple,TB,<:Tuple,<:Tuple,<:Tuple}
-) where {TB}
+) where {TB<:Tuple}
     return model.boundary_nl
 end
 
@@ -64,7 +64,7 @@ See also: [`CTModels.Components.control_constraints_box`](@ref), [`CTModels.Comp
 """
 function state_constraints_box(
     model::ConstraintsModel{<:Tuple,<:Tuple,TS,<:Tuple,<:Tuple}
-) where {TS}
+) where {TS<:Tuple}
     return model.state_box
 end
 
@@ -80,7 +80,7 @@ See also: [`CTModels.Components.state_constraints_box`](@ref), [`CTModels.Compon
 """
 function control_constraints_box(
     model::ConstraintsModel{<:Tuple,<:Tuple,<:Tuple,TC,<:Tuple}
-) where {TC}
+) where {TC<:Tuple}
     return model.control_box
 end
 
@@ -96,7 +96,7 @@ See also: [`CTModels.Components.state_constraints_box`](@ref), [`CTModels.Compon
 """
 function variable_constraints_box(
     model::ConstraintsModel{<:Tuple,<:Tuple,<:Tuple,<:Tuple,TV}
-) where {TV}
+) where {TV<:Tuple}
     return model.variable_box
 end
 

--- a/src/Components/functors.jl
+++ b/src/Components/functors.jl
@@ -67,7 +67,7 @@ g = CoercedTrajectory(t -> [t, 2t], identity)
 g(0.5)   # returns [0.5, 1.0]
 ```
 """
-struct CoercedTrajectory{F,C} <: Function
+struct CoercedTrajectory{F,C<:Union{typeof(only),typeof(identity)}} <: Function
     inner::F
     coerce::C
 end

--- a/src/Init/init_functors.jl
+++ b/src/Init/init_functors.jl
@@ -109,13 +109,15 @@ f = MergedTrajectory(base, comps, 2, :state)
 f(0.5)   # returns [0.0, sin(0.5)]
 ```
 """
-struct MergedTrajectory{F,C} <: Function
+struct MergedTrajectory{F,C<:AbstractDict{Int,<:Function}} <: Function
     base::F
     comps::C       # Dict{Int,Function}
     dim::Int
     role::Symbol
 
-    function MergedTrajectory{F,C}(base::F, comps::C, dim::Int, role::Symbol) where {F,C}
+    function MergedTrajectory{F,C}(
+        base::F, comps::C, dim::Int, role::Symbol
+    ) where {F,C<:AbstractDict{Int,<:Function}}
         for i in keys(comps)
             if !(1 <= i <= dim)
                 throw(
@@ -133,7 +135,9 @@ struct MergedTrajectory{F,C} <: Function
     end
 end
 
-function MergedTrajectory(base::F, comps::C, dim::Int, role::Symbol) where {F,C}
+function MergedTrajectory(
+    base::F, comps::C, dim::Int, role::Symbol
+) where {F,C<:AbstractDict{Int,<:Function}}
     return MergedTrajectory{F,C}(base, comps, dim, role)
 end
 

--- a/src/Models/model.jl
+++ b/src/Models/model.jl
@@ -114,7 +114,7 @@ end
 
 Traits.has_time_dependence_trait(::Model) = true
 
-Traits.time_dependence(::Model{TD}) where {TD} = TD
+Traits.time_dependence(::Model{TD}) where {TD<:TimeDependence} = TD
 
 Traits.has_variable_dependence_trait(::Model) = true
 

--- a/test/suite/meta/test_where_bounds.jl
+++ b/test/suite/meta/test_where_bounds.jl
@@ -1,0 +1,67 @@
+"""
+Regression guard for the `where`-clause bound-dropping pitfall (see
+`.reports/2026-07-12_alias-where-bounds-audit.md` and the Handbook rule in
+`philosophy/types-traits-interfaces.md#aliases-and-where`).
+
+A `where {X}` clause that names a type parameter without repeating the bound the
+struct already declares for it silently widens it to `<:Any`. This is invisible
+via `isa` on concrete instances, but it breaks Julia's method-specificity ranking
+the moment a competing method exists — either mis-dispatching silently or throwing
+`MethodError: ... is ambiguous`.
+
+CTModels has no parametric aliases, so the CTFlows-style `Alias <: Parent` guard
+does not apply. Instead this test asserts, for each method whose `where`-clause was
+tightened, that the induced `TypeVar`'s upper bound is the intended bound and not
+`Any`. A future edit that drops one of these bounds again fails loudly here.
+"""
+
+module TestWhereBounds
+
+import Test: Test
+import CTBase.Traits: Traits
+import CTModels.Components: Components
+import CTModels.Models: Models
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+# Upper bound of the outermost `where`-var of the method dispatched for `argtypes`.
+# Returns `nothing` when the signature is not a `UnionAll` (i.e. no `where`-var at
+# all), which fails the `=== expected` assertions below just as a widened bound does.
+function _where_ub(f, argtypes::Type{<:Tuple})
+    m = which(f, argtypes)
+    return m.sig isa UnionAll ? m.sig.var.ub : nothing
+end
+
+function test_where_bounds()
+    Test.@testset "where-clause bound-dropping regression guard" verbose = VERBOSE showtiming =
+        SHOWTIMING begin
+
+        # The 5 ConstraintsModel accessors: each restricts 4 params to <:Tuple in the
+        # type-parameter position and extracts the 5th via a `where`-clause that must
+        # repeat the same <:Tuple bound (constraints_accessors.jl). `which` on a bare
+        # ConstraintsModel argument selects the ConstraintsModel-specific method (the
+        # convenience Model-forwarding overload does not match a ConstraintsModel).
+        Test.@testset "ConstraintsModel accessors — where-var ub === Tuple" begin
+            CM = Tuple{Components.ConstraintsModel}
+            Test.@test _where_ub(Components.path_constraints_nl, CM) === Tuple
+            Test.@test _where_ub(Components.boundary_constraints_nl, CM) === Tuple
+            Test.@test _where_ub(Components.state_constraints_box, CM) === Tuple
+            Test.@test _where_ub(Components.control_constraints_box, CM) === Tuple
+            Test.@test _where_ub(Components.variable_constraints_box, CM) === Tuple
+        end
+
+        # Model's time-dependence trait reads TD from the type parameter; the method's
+        # `where`-clause must repeat the `TD<:TimeDependence` bound the Model struct
+        # declares (model.jl).
+        Test.@testset "Model time_dependence — where-var ub === TimeDependence" begin
+            Test.@test _where_ub(Traits.time_dependence, Tuple{Models.Model}) ===
+                Components.TimeDependence
+        end
+    end
+end
+
+end # module
+
+# CRITICAL: Redefine in outer scope for TestRunner
+test_where_bounds() = TestWhereBounds.test_where_bounds()


### PR DESCRIPTION
## Context

The [2026-07-12 alias/`where` bound-dropping audit](.reports/2026-07-12_alias-where-bounds-audit.md) found **6 genuine bugs**: methods whose `where {X}` clause names a type parameter without repeating the bound the struct already declares, silently widening it to `<:Any`. This is invisible via `isa` on concrete instances, but it breaks Julia's method-specificity ranking the moment a competing method exists — either mis-dispatching silently or throwing `MethodError: ... is ambiguous`.

All changes only **tighten** `where`/field bounds. Tightening a bound cannot make a previously-valid call invalid, so there is **no behaviour change**.

## Changes

**The 6 fixes**
- [`Models/model.jl`](src/Models/model.jl): `time_dependence(::Model{TD})` → `where {TD<:TimeDependence}` (matches the struct declaration and inner constructor).
- [`Components/constraints_accessors.jl`](src/Components/constraints_accessors.jl): the 5 `ConstraintsModel` accessors each restrict 4 params to `<:Tuple` in the type-parameter position but extracted the 5th via a bare `where` — now repeat `<:Tuple` on it.

**§5 hardening** (both verified safe against every construction site, production + tests)
- `CoercedTrajectory`: `coerce::C` is always `only`/`identity` → `C<:Union{typeof(only),typeof(identity)}`.
- `MergedTrajectory`: `comps::C` is always `Dict{Int,Function}` → `C<:AbstractDict{Int,<:Function}` (struct + both hand-written constructors).

**Regression guard**
- New [`test/suite/meta/test_where_bounds.jl`](test/suite/meta/test_where_bounds.jl) (auto-discovered by the runner) asserts each fixed method's induced `TypeVar` upper bound is the intended bound, not `Any` — a future re-drop fails loudly here.

## Verification

- Precompile clean (no method-overwrite).
- Full suite **4014/4014 pass**, including the new guard (6/6) and Aqua's ambiguity / unbound-parameter checks (11/11). No masked ambiguity surfaced from the shared `ConstraintsModel` fixes.

## Note

The audit's "exactly one method per name" was slightly off — each accessor also has a convenience `Model`-forwarding overload. Harmless; the guard uses `which(f, Tuple{ConstraintsModel})` to target the correct method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)