### PR TITLE
docs: review getting-started and performance pages

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,13 @@ using MarkdownAST: MarkdownAST
 # ═══════════════════════════════════════════════════════════════════════════════
 # Configuration
 # ═══════════════════════════════════════════════════════════════════════════════
+# if draft is true, then the julia code from .md is not executed
+# to disable the draft mode in a specific markdown file, use the following:
+#=
+```@meta
+Draft = false
+```
+=#
 draft = false # Draft mode: if true, @example blocks in markdown are not executed
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -87,11 +87,11 @@ ocp = CTModels.build(pre)
 
 The built `Model` exposes its structure through accessors:
 
-```@example gs
-(CTModels.state_dimension(ocp),
- CTModels.control_dimension(ocp),
- CTModels.is_autonomous(ocp),
- CTModels.has_lagrange_cost(ocp))
+```@repl gs
+CTModels.state_dimension(ocp)
+CTModels.control_dimension(ocp)
+CTModels.is_autonomous(ocp)
+CTModels.has_lagrange_cost(ocp)
 ```
 
 ### Assembling a solution
@@ -118,20 +118,29 @@ sol = CTModels.build_solution(ocp, T, X, U, Float64[], P;
 
 Trajectories are returned as callables (interpolated from the samples):
 
-```@example gs
+```@repl gs
 x = CTModels.state(sol)
-(x(0.5),
- CTModels.objective(sol),
- CTModels.successful(sol))
+x(0.5)
+CTModels.objective(sol)
+CTModels.successful(sol)
 ```
 
 ### Building an initial guess
+
+An initial guess provides the solver with a starting point for the state and control trajectories.
+It is built from the `Model` and a pair of functions that return the guessed state and control at any time `t`:
 
 ```@example gs
 init = CTModels.build_initial_guess(ocp,
     (state=t -> [0.0, 0.0], control=t -> [0.1])
 )
-(init.state(0.5), init.control(0.5))
+```
+
+The returned object exposes the guessed trajectories as callables, just like a `Solution`:
+
+```@repl gs
+init.state(0.5)
+init.control(0.5)
 ```
 
 ## Next Steps

--- a/docs/src/guide/performance.md
+++ b/docs/src/guide/performance.md
@@ -1,9 +1,8 @@
+# Performance & Type Stability
+
 ```@meta
 CurrentModule = CTModels
-Draft = false
 ```
-
-# Performance & Type Stability
 
 This guide explains **how CTModels keeps its runtime-critical code fast**, and how a
 contributor can check that a change has not introduced a regression.


### PR DESCRIPTION
## Summary

This PR improves the documentation with minor fixes and additions:

- **getting-started.md**: Added explanatory text in the "Building an initial guess" section. Split the single `@repl` block into an `@example` block (for construction) and an `@repl` block (for querying), so the construction code is hidden from the REPL output.
- **performance.md**: Moved the `@meta` block before the title heading (DocumenterVitepress convention).
- **make.jl**: Added a comment explaining how the draft mode works and how to disable it per-file.