### PR TITLE
feat: redesign Solution display — single tree, conditional fields, CTBase palette

### DIFF
--- a/docs/src/solution/overview.md
+++ b/docs/src/solution/overview.md
@@ -91,3 +91,106 @@ CTModels.successful(sol)
 
 Each accessor dispatches on a typed field, so reading a solution never inspects raw
 closures. The following pages take each group in turn.
+
+## Displaying a solution
+
+Typing a `Solution` in the REPL renders a single tree whose branches adapt to the
+data that was actually provided — fields left as `NotProvided` are silently omitted.
+
+### Case 1 — Full solver diagnostics
+
+The typical output when an NLP solver fills every field:
+
+```@example sol_display
+using CTModels
+pre = CTModels.PreModel()
+CTModels.variable!(pre, 0)
+CTModels.time!(pre; t0=0.0, tf=1.0)
+CTModels.state!(pre, 2)
+CTModels.control!(pre, 1)
+CTModels.dynamics!(pre, (r, t, x, u, v) -> (r[1] = x[2]; r[2] = u[1]; nothing))
+CTModels.objective!(pre, :min; lagrange=(t, x, u, v) -> u[1]^2)
+CTModels.time_dependence!(pre; autonomous=true)
+ocp = CTModels.build(pre)
+N = 11; T = collect(range(0.0, 1.0; length=N))
+X = hcat(cos.(T), -sin.(T)); U = reshape(-cos.(T), N, 1); P = zeros(N, 2)
+sol = CTModels.build_solution(ocp, T, X, U, Float64[], P;
+    objective=0.5,
+    iterations=10,
+    constraints_violation=1e-9,
+    message="Solve_Succeeded",
+    status=:Solve_Succeeded,
+    successful=true,
+)
+```
+
+### Case 2 — Lightweight flow result
+
+When only a message is meaningful (e.g. from CTFlows),
+`iterations`, `status`, and `constraints_violation` are simply not shown:
+
+```@example sol_display
+sol_flow = CTModels.build_solution(ocp, T, X, U, Float64[], P;
+    objective=0.5,
+    message="Solution computed by CTFlows OCP flow",
+    successful=true,
+)
+sol_flow
+```
+
+### Case 3 — With an optimisation variable
+
+When the OCP has an optimisation variable, it appears between the objective and the
+solver metadata:
+
+```@example sol_display
+pre_v = CTModels.PreModel()
+CTModels.variable!(pre_v, 1, "T", ["T"])
+CTModels.time!(pre_v; t0=0.0, tf=1.0)
+CTModels.state!(pre_v, 1)
+CTModels.control!(pre_v, 1)
+CTModels.dynamics!(pre_v, (r, t, x, u, v) -> (r[1] = u[1]; nothing))
+CTModels.objective!(pre_v, :min; mayer=(x0, xf, v) -> v[1]^2)
+CTModels.time_dependence!(pre_v; autonomous=true)
+ocp_v = CTModels.build(pre_v)
+Xv = reshape(T, N, 1); Uv = ones(N, 1); Pv = zeros(N, 1)
+sol_v = CTModels.build_solution(ocp_v, T, Xv, Uv, [1.5], Pv;
+    objective=2.25,
+    iterations=7,
+    constraints_violation=1e-11,
+    message="optimal",
+    status=:first_order,
+    successful=true,
+)
+```
+
+### Case 4 — Variable duals and boundary duals
+
+When a solver also provides dual variables (Lagrange multipliers), they appear nested
+under the variable and as a separate "Boundary duals" row:
+
+```@example sol_display
+pre_d = CTModels.PreModel()
+CTModels.variable!(pre_d, 1, "T", ["T"])
+CTModels.time!(pre_d; t0=0.0, tf=1.0)
+CTModels.state!(pre_d, 1)
+CTModels.control!(pre_d, 1)
+CTModels.dynamics!(pre_d, (r, t, x, u, v) -> (r[1] = u[1]; nothing))
+CTModels.objective!(pre_d, :min; mayer=(x0, xf, v) -> v[1]^2)
+CTModels.constraint!(pre_d, :variable; rg=1:1, lb=[0.5], ub=[2.0], label=:T_box)
+bc!(r, x0, xf, v) = (r[1] = x0[1]; r[2] = xf[1] - 1.0; nothing)
+CTModels.constraint!(pre_d, :boundary; f=bc!, lb=zeros(2), ub=zeros(2), label=:bc)
+CTModels.time_dependence!(pre_d; autonomous=true)
+ocp_d = CTModels.build(pre_d)
+sol_d = CTModels.build_solution(ocp_d, T, Xv, Uv, [1.5], Pv;
+    objective=2.25,
+    iterations=12,
+    constraints_violation=2e-10,
+    message="optimal",
+    status=:first_order,
+    successful=true,
+    variable_constraints_lb_dual=[0.0],
+    variable_constraints_ub_dual=[0.3],
+    boundary_constraints_dual=[1.2, -0.8],
+)
+```

--- a/src/Solutions/build_solution.jl
+++ b/src/Solutions/build_solution.jl
@@ -198,10 +198,10 @@ function build_solution(
     v::Vector{Float64},
     P::TP;
     objective::Float64,
-    iterations::Int,
-    constraints_violation::Float64,
-    message::String,
-    status::Symbol,
+    iterations::Union{Int, Core.NotProvidedType}=Core.NotProvided,
+    constraints_violation::Union{Float64, Core.NotProvidedType}=Core.NotProvided,
+    message::Union{String, Core.NotProvidedType}=Core.NotProvided,
+    status::Union{Symbol, Core.NotProvidedType}=Core.NotProvided,
     successful::Bool,
     path_constraints_dual::TPCD=__constraints(),
     boundary_constraints_dual::Union{Vector{Float64},Nothing}=__constraints(),
@@ -539,10 +539,10 @@ function build_solution(
     v::Vector{Float64},
     P::TP;
     objective::Float64,
-    iterations::Int,
-    constraints_violation::Float64,
-    message::String,
-    status::Symbol,
+    iterations::Union{Int, Core.NotProvidedType}=Core.NotProvided,
+    constraints_violation::Union{Float64, Core.NotProvidedType}=Core.NotProvided,
+    message::Union{String, Core.NotProvidedType}=Core.NotProvided,
+    status::Union{Symbol, Core.NotProvidedType}=Core.NotProvided,
     successful::Bool,
     path_constraints_dual::TPCD=__constraints(),
     boundary_constraints_dual::Union{Vector{Float64},Nothing}=__constraints(),
@@ -1388,7 +1388,7 @@ $(TYPEDSIGNATURES)
 Return the number of iterations (if solved by an iterative method).
 
 """
-function iterations(sol::Solution)::Int
+function iterations(sol::Solution)
     return sol.solver_infos.iterations
 end
 
@@ -1398,7 +1398,7 @@ $(TYPEDSIGNATURES)
 Return the status criterion (a Symbol).
 
 """
-function status(sol::Solution)::Symbol
+function status(sol::Solution)
     return sol.solver_infos.status
 end
 
@@ -1408,7 +1408,7 @@ $(TYPEDSIGNATURES)
 Return the message associated to the status criterion.
 
 """
-function message(sol::Solution)::String
+function message(sol::Solution)
     return sol.solver_infos.message
 end
 
@@ -1428,7 +1428,7 @@ $(TYPEDSIGNATURES)
 Return the constraints violation.
 
 """
-function constraints_violation(sol::Solution)::Float64
+function constraints_violation(sol::Solution)
     return sol.solver_infos.constraints_violation
 end
 

--- a/src/Solutions/show.jl
+++ b/src/Solutions/show.jl
@@ -7,8 +7,16 @@ $(TYPEDSIGNATURES)
 
 Print the solution to `io` with semantic ANSI formatting.
 
-Displays the solver summary (status, iterations, objective, constraints violation),
-the optimisation variable (if defined), and boundary constraint duals (if present).
+Displays the objective, the optimisation variable (if defined), boundary constraint
+duals (if present), and solver metadata (iterations, status, message, constraints
+violation) — each field only when it has been provided (not `NotProvided`).
+
+The display is a single tree rooted at "Solution":
+- `│  label : value` for interior rows
+- `└─ label : value` for the last row
+- `│  ├─ / └─` for nested sub-rows (variable duals)
+- An empty `│` separator appears between primal data and solver metadata
+  when both sections are non-empty.
 
 # Returns
 - `Nothing`: Prints to `io` and returns nothing.
@@ -18,143 +26,107 @@ See also: [`CTModels.Solutions.Solution`](@ref)
 function Base.show(io::IO, ::MIME"text/plain", sol::Solution)
     fmt = Core.get_format_codes(io)
 
-    # Solver summary
-    ok = Solutions.successful(sol)
+    # ── Header ──────────────────────────────────────────────────────────────
+    ok      = Solutions.successful(sol)
     ok_code = ok ? fmt.success : fmt.error
-    println(io, fmt.name, "• Solver:", fmt.reset)
-    println(io, "  ", ok_code, "✓ Successful  : ", ok, fmt.reset)
-    println(
-        io,
-        "  ",
-        fmt.label,
-        "│  Status     : ",
-        fmt.reset,
-        fmt.value,
-        Solutions.status(sol),
-        fmt.reset,
-    )
-    println(
-        io,
-        "  ",
-        fmt.label,
-        "│  Message    : ",
-        fmt.reset,
-        fmt.value,
-        Solutions.message(sol),
-        fmt.reset,
-    )
-    println(
-        io,
-        "  ",
-        fmt.label,
-        "│  Iterations : ",
-        fmt.reset,
-        fmt.value,
-        Solutions.iterations(sol),
-        fmt.reset,
-    )
-    println(
-        io,
-        "  ",
-        fmt.label,
-        "│  Objective  : ",
-        fmt.reset,
-        fmt.value,
-        Components.objective(sol),
-        fmt.reset,
-    )
-    println(
-        io,
-        "  ",
-        fmt.label,
-        "└─ Constraints violation : ",
-        fmt.reset,
-        fmt.value,
-        Solutions.constraints_violation(sol),
-        fmt.reset,
-    )
+    ok_sym  = ok ? "✓ successful" : "✗ failed"
+    println(io, fmt.name, "Solution", fmt.reset, "  ", ok_code, ok_sym, fmt.reset)
 
-    # Variable (if defined)
-    if Models.variable_dimension(sol) > 0
-        components = Models.variable_components(sol)
-        var_name = Models.variable_name(sol)
+    # ── Optional solver-metadata — only display when provided ────────────────
+    _np     = Core.NotProvidedType
+    _iter   = Solutions.iterations(sol)
+    _status = Solutions.status(sol)
+    _msg    = Solutions.message(sol)
+    _cv     = Solutions.constraints_violation(sol)
+    has_iter   = !(_iter   isa _np)
+    has_status = !(_status isa _np)
+    has_msg    = !(_msg    isa _np)
+    has_cv     = !(_cv     isa _np)
 
-        # Simplified case: dimension 1 and name identical
-        if Models.variable_dimension(sol) == 1 && var_name == components[1]
-            println(
-                io,
-                "\n",
-                fmt.name,
-                "• Variable:",
-                fmt.reset,
-                " ",
-                fmt.value,
-                var_name,
-                fmt.reset,
-                " = ",
-                fmt.value,
-                Components.variable(sol),
-                fmt.reset,
-            )
-        else
-            println(
-                io,
-                "\n",
-                fmt.name,
-                "• Variable:",
-                fmt.reset,
-                " ",
-                fmt.value,
-                var_name,
-                fmt.reset,
-                " = (",
-                fmt.value,
-                join(components, ", "),
-                fmt.reset,
-                ") = ",
-                fmt.value,
-                Components.variable(sol),
-                fmt.reset,
-            )
-        end
-        if Solutions.has_duals(sol) &&
-            Solutions.dim_dual_variable_constraints_box(sol) > 0 &&
-            Components.dim_variable_constraints_box(Solutions.model(sol)) > 0
-            println(
-                io,
-                "  ",
-                fmt.label,
-                "│  Var dual (lb) : ",
-                fmt.reset,
-                fmt.value,
-                Solutions.variable_constraints_lb_dual(sol),
-                fmt.reset,
-            )
-            println(
-                io,
-                "  ",
-                fmt.label,
-                "└─ Var dual (ub) : ",
-                fmt.reset,
-                fmt.value,
-                Solutions.variable_constraints_ub_dual(sol),
-                fmt.reset,
-            )
-        end
-    end
+    # ── Primal-extra presence ────────────────────────────────────────────────
+    has_var = Models.variable_dimension(sol) > 0
+    has_bd  = Solutions.has_duals(sol) && Components.dim_boundary_constraints_nl(sol) > 0
+    has_vd  = has_var &&
+              Solutions.has_duals(sol) &&
+              Solutions.dim_dual_variable_constraints_box(sol) > 0 &&
+              Components.dim_variable_constraints_box(Solutions.model(sol)) > 0
 
-    # Boundary constraints duals
-    if Solutions.has_duals(sol) && Components.dim_boundary_constraints_nl(sol) > 0
+    has_solver_meta  = has_iter || has_status || has_msg || has_cv
+    has_primal_extra = has_var || has_bd
+
+    # ── Build ordered list of top-level item tags ────────────────────────────
+    tags = Symbol[]
+    push!(tags, :obj)
+    has_var    && push!(tags, :var)
+    has_bd     && push!(tags, :bd)
+    has_iter   && push!(tags, :iter)
+    has_status && push!(tags, :status)
+    has_msg    && push!(tags, :msg)
+    has_cv     && push!(tags, :cv)
+
+    last_tag = last(tags)
+
+    # ── Connector for each top-level tag ─────────────────────────────────────
+    conn(tag) = tag === last_tag ? "  └─ " : "  │  "
+
+    # ── Print one labeled field row ──────────────────────────────────────────
+    function _row(c, label, value)
         println(
             io,
-            "\n",
-            fmt.name,
-            "• Boundary duals:",
-            fmt.reset,
-            " ",
-            fmt.value,
-            Solutions.boundary_constraints_dual(sol),
-            fmt.reset,
+            fmt.muted, c, fmt.reset,
+            fmt.label, label, " : ", fmt.reset,
+            fmt.value, value, fmt.reset,
         )
     end
+
+    # ── Objective ────────────────────────────────────────────────────────────
+    _row(conn(:obj), "Objective", string(Components.objective(sol)))
+
+    # ── Variable (optional) ──────────────────────────────────────────────────
+    if has_var
+        dim_v     = Models.variable_dimension(sol)
+        var_val   = Components.variable(sol)
+        var_name  = Models.variable_name(sol)
+        var_comps = Models.variable_components(sol)
+
+        var_label =
+            if dim_v == 1 || var_name == var_comps[1]
+                var_name
+            else
+                var_name * " = (" * join(var_comps, ", ") * ")"
+            end
+
+        c = conn(:var)
+        _row(c, var_label, string(var_val))
+
+        if has_vd
+            lb = Solutions.variable_constraints_lb_dual(sol)
+            ub = Solutions.variable_constraints_ub_dual(sol)
+            if c == "  └─ "
+                println(io, fmt.muted, "     ├─ ", fmt.reset, fmt.label, "dual lb : ", fmt.reset, fmt.value, string(lb), fmt.reset)
+                println(io, fmt.muted, "     └─ ", fmt.reset, fmt.label, "dual ub : ", fmt.reset, fmt.value, string(ub), fmt.reset)
+            else
+                println(io, fmt.muted, "  │  ├─ ", fmt.reset, fmt.label, "dual lb : ", fmt.reset, fmt.value, string(lb), fmt.reset)
+                println(io, fmt.muted, "  │  └─ ", fmt.reset, fmt.label, "dual ub : ", fmt.reset, fmt.value, string(ub), fmt.reset)
+            end
+        end
+    end
+
+    # ── Boundary duals (optional) ─────────────────────────────────────────────
+    if has_bd
+        _row(conn(:bd), "Boundary duals", string(Solutions.boundary_constraints_dual(sol)))
+    end
+
+    # ── Separator between primal data and solver metadata ────────────────────
+    if has_solver_meta && has_primal_extra
+        println(io, fmt.muted, "  │", fmt.reset)
+    end
+
+    # ── Solver metadata ───────────────────────────────────────────────────────
+    has_iter   && _row(conn(:iter),   "Iterations",            string(_iter))
+    has_status && _row(conn(:status), "Status",                string(_status))
+    has_msg    && _row(conn(:msg),    "Message",               string(_msg))
+    has_cv     && _row(conn(:cv),     "Constraints violation", string(_cv))
+
+    return nothing
 end

--- a/src/Solutions/solution_types.jl
+++ b/src/Solutions/solution_types.jl
@@ -253,11 +253,11 @@ true
 ```
 """
 struct SolverInfos{V,TI<:Dict{Symbol,V}} <: AbstractSolverInfos
-    iterations::Int
-    status::Symbol
-    message::String
+    iterations::Union{Int, Core.NotProvidedType}
+    status::Union{Symbol, Core.NotProvidedType}
+    message::Union{String, Core.NotProvidedType}
     successful::Bool
-    constraints_violation::Float64
+    constraints_violation::Union{Float64, Core.NotProvidedType}
     infos::TI
 end
 

--- a/test/suite/solutions/test_empty_dual_model.jl
+++ b/test/suite/solutions/test_empty_dual_model.jl
@@ -115,7 +115,7 @@ function test_empty_dual_model()
             sol = _make_dualfree_solution(m)
             str = repr(MIME("text/plain"), sol)
             Test.@test str isa String
-            Test.@test occursin("Solver", str)
+            Test.@test occursin("Solution", str)
             # the model has boundary constraints but the solution carries no duals,
             # so the boundary-duals block must not appear
             Test.@test !occursin("Boundary duals", str)

--- a/test/suite/solutions/test_solution_show.jl
+++ b/test/suite/solutions/test_solution_show.jl
@@ -16,8 +16,7 @@ function test_solution_show()
         # UNIT TESTS - Solution show output
         # ====================================================================
 
-        Test.@testset "Solution text/plain show" begin
-            # create a minimal OCP
+        Test.@testset "Solution text/plain show — full solver info" begin
             pre_ocp = Building.PreModel()
             Building.time!(pre_ocp; t0=0.0, tf=1.0)
             Building.state!(pre_ocp, 1, "x", ["x"])
@@ -34,22 +33,13 @@ function test_solution_show()
             Building.time_dependence!(pre_ocp; autonomous=false)
             ocp = Building.build(pre_ocp)
 
-            # create a solution
             T = [0.0, 0.5, 1.0]
-            X = zeros(3, 1)
-            X[:, 1] = [0.0, 0.5, 1.0]
-            U = zeros(3, 1)
-            U[:, 1] = [1.0, 2.0, 3.0]
+            X = zeros(3, 1); X[:, 1] = [0.0, 0.5, 1.0]
+            U = zeros(3, 1); U[:, 1] = [1.0, 2.0, 3.0]
             v = Float64[]
-            P = zeros(3, 1)
-            P[:, 1] = [0.1, 0.2, 0.3]
+            P = zeros(3, 1); P[:, 1] = [0.1, 0.2, 0.3]
             sol = Solutions.build_solution(
-                ocp,
-                T,
-                X,
-                U,
-                v,
-                P;
+                ocp, T, X, U, v, P;
                 objective=0.5,
                 iterations=10,
                 constraints_violation=1e-8,
@@ -62,8 +52,8 @@ function test_solution_show()
             show(io, MIME"text/plain"(), sol)
             s = String(take!(io))
 
-            Test.@test occursin("Solver", s)
-            Test.@test occursin("Successful", s)
+            Test.@test occursin("Solution", s)
+            Test.@test occursin("successful", s)
             Test.@test occursin("Status", s)
             Test.@test occursin("Message", s)
             Test.@test occursin("Iterations", s)
@@ -71,10 +61,53 @@ function test_solution_show()
             Test.@test occursin("Constraints violation", s)
             Test.@test occursin("converged", s)
             Test.@test occursin("first_order", s)
+            Test.@test !occursin("Solver", s)
+        end
+
+        Test.@testset "Solution show — NotProvided fields omitted" begin
+            pre_ocp = Building.PreModel()
+            Building.time!(pre_ocp; t0=0.0, tf=1.0)
+            Building.state!(pre_ocp, 1, "x", ["x"])
+            Building.control!(pre_ocp, 1, "u", ["u"])
+            Building.variable!(pre_ocp, 0)
+            dynamics!(r, t, x, u, v) = (r[1]=u[1]; nothing)
+            Building.dynamics!(pre_ocp, dynamics!)
+            Building.objective!(
+                pre_ocp,
+                :min;
+                mayer=(x0, xf, v) -> 0.0,
+                lagrange=(t, x, u, v) -> 0.5 * u[1]^2,
+            )
+            Building.time_dependence!(pre_ocp; autonomous=false)
+            ocp = Building.build(pre_ocp)
+
+            T = [0.0, 1.0]
+            X = zeros(2, 1); X[:, 1] = [0.0, 1.0]
+            U = zeros(2, 1); U[:, 1] = [1.0, 2.0]
+            v = Float64[]
+            P = zeros(2, 1); P[:, 1] = [0.1, 0.2]
+            sol = Solutions.build_solution(
+                ocp, T, X, U, v, P;
+                objective=7.389,
+                message="Solution computed by flow",
+                successful=true,
+            )
+
+            io = IOBuffer()
+            show(io, MIME"text/plain"(), sol)
+            s = String(take!(io))
+
+            Test.@test occursin("Solution", s)
+            Test.@test occursin("Objective", s)
+            Test.@test occursin("Message", s)
+            Test.@test occursin("flow", s)
+            Test.@test !occursin("Iterations", s)
+            Test.@test !occursin("Status", s)
+            Test.@test !occursin("Constraints violation", s)
+            Test.@test !occursin("Solver", s)
         end
 
         Test.@testset "Solution show with variable" begin
-            # create an OCP with a variable
             pre_ocp = Building.PreModel()
             Building.time!(pre_ocp; t0=0.0, tf=1.0)
             Building.state!(pre_ocp, 1, "x", ["x"])
@@ -92,20 +125,12 @@ function test_solution_show()
             ocp = Building.build(pre_ocp)
 
             T = [0.0, 1.0]
-            X = zeros(2, 1)
-            X[:, 1] = [0.0, 1.0]
-            U = zeros(2, 1)
-            U[:, 1] = [1.0, 2.0]
+            X = zeros(2, 1); X[:, 1] = [0.0, 1.0]
+            U = zeros(2, 1); U[:, 1] = [1.0, 2.0]
             v = [5.0]
-            P = zeros(2, 1)
-            P[:, 1] = [0.1, 0.2]
+            P = zeros(2, 1); P[:, 1] = [0.1, 0.2]
             sol = Solutions.build_solution(
-                ocp,
-                T,
-                X,
-                U,
-                v,
-                P;
+                ocp, T, X, U, v, P;
                 objective=1.0,
                 iterations=5,
                 constraints_violation=0.0,
@@ -118,11 +143,12 @@ function test_solution_show()
             show(io, MIME"text/plain"(), sol)
             s = String(take!(io))
 
-            Test.@test occursin("Variable", s)
+            Test.@test occursin("v", s)
             Test.@test occursin("5.0", s)
+            Test.@test occursin("│", s)
         end
 
-        Test.@testset "Solution show with unsuccessful solver" begin
+        Test.@testset "Solution show — unsuccessful solver" begin
             pre_ocp = Building.PreModel()
             Building.time!(pre_ocp; t0=0.0, tf=1.0)
             Building.state!(pre_ocp, 1, "x", ["x"])
@@ -140,20 +166,12 @@ function test_solution_show()
             ocp = Building.build(pre_ocp)
 
             T = [0.0, 1.0]
-            X = zeros(2, 1)
-            X[:, 1] = [0.0, 1.0]
-            U = zeros(2, 1)
-            U[:, 1] = [1.0, 2.0]
+            X = zeros(2, 1); X[:, 1] = [0.0, 1.0]
+            U = zeros(2, 1); U[:, 1] = [1.0, 2.0]
             v = Float64[]
-            P = zeros(2, 1)
-            P[:, 1] = [0.1, 0.2]
+            P = zeros(2, 1); P[:, 1] = [0.1, 0.2]
             sol = Solutions.build_solution(
-                ocp,
-                T,
-                X,
-                U,
-                v,
-                P;
+                ocp, T, X, U, v, P;
                 objective=1.0,
                 iterations=3,
                 constraints_violation=100.0,
@@ -166,10 +184,10 @@ function test_solution_show()
             show(io, MIME"text/plain"(), sol)
             s = String(take!(io))
 
-            Test.@test occursin("Solver", s)
-            Test.@test occursin("false", s)
+            Test.@test occursin("Solution", s)
             Test.@test occursin("failed", s)
             Test.@test occursin("not_solved", s)
+            Test.@test !occursin("Solver", s)
         end
     end
 end


### PR DESCRIPTION
## Summary

Redesigns the `Solution` REPL display for clarity and consistency with the CTBase palette conventions.

### Before

```
• Solver:
  ✓ Successful  : true
  │  Status     : Solve_Succeeded
  │  Message    : Solve_Succeeded
  │  Iterations : 10
  │  Objective  : 0.5
  └─ Constraints violation : 1.0e-9

• Variable: v = 1.5

• Boundary duals: [1.2, -0.8]
```

### After

Single tree, no bullet points, fields omitted when not provided:

```
Solution  ✓ successful
  │  Objective : 0.5
  │  T : 1.5
  │  ├─ dual lb : [0.0]
  │  └─ dual ub : [0.3]
  │  Boundary duals : [1.2, -0.8]
  │
  │  Iterations : 10
  │  Status : first_order
  │  Message : optimal
  └─ Constraints violation : 1.0e-9
```

Flow result (no solver metadata):
```
Solution  ✓ successful
  │  Objective : 0.5
  └─ Message : Solution computed by CTFlows OCP flow
```

## Changes

### `src/Solutions/solution_types.jl`
- `SolverInfos`: `iterations`, `status`, `message`, `constraints_violation` are now `Union{T, Core.NotProvidedType}` instead of mandatory concrete types.

### `src/Solutions/build_solution.jl`
- Both `build_solution` overloads: the four fields above default to `Core.NotProvided`.
- Accessor return-type annotations removed (they now return `Union{T, NotProvidedType}`).

### `src/Solutions/show.jl`
- Complete rewrite: single tree using `│`/`└─`/`├─`, `fmt.muted` for structural chars, `fmt.label`/`fmt.value` for content.
- Empty `│` separator appears between *primal data* (objective, variable, duals) and *solver metadata* (iterations, status, message, cv) when both sections are non-empty.
- `NotProvided` fields are silently omitted.

### Tests
- `test_solution_show.jl`: 4 test cases, including a `NotProvided`-omission case.
- `test_empty_dual_model.jl`: `"Solver"` → `"Solution"` string check.

### `docs/src/solution/overview.md`
- New "Displaying a solution" section with 4 executable `@repl` examples.

## Related

- CTFlows cleanup tracked in: https://github.com/control-toolbox/CTFlows.jl/issues/323
