### PR TITLE
Widen CTBase compat to 0.28

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,6 +4,13 @@
 
 This document describes breaking changes in CTModels releases and how to migrate your code.
 
+## [0.15.3-beta] - 2026-07-13
+
+### Compatibility
+
+- **No breaking changes.** CTBase compat is widened from `0.27` to `0.27, 0.28`.
+  Existing code targeting CTBase 0.27 continues to work unchanged.
+
 ## [0.15.0-beta] - 2026-07-09
 
 The plotting extension is rewritten on top of the generic `CTBase.Plotting` engine. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.3-beta] - 2026-07-13
+
+### 📦 Dependencies
+
+- **Widened CTBase compatibility**: Extended support to CTBase 0.28 (compat now
+  `0.27, 0.28` in both `Project.toml` and `docs/Project.toml`).
+- **No breaking changes**: Full backward compatibility maintained with CTBase 0.27.
+  No source changes required. See [BREAKING.md](BREAKING.md).
+
 ## [0.15.2-beta] - 2026-07-10
 
 ### 🐛 Bug Fixes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.15.2-beta"
+version = "0.15.3-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -26,7 +26,7 @@ CTModelsPlots = "Plots"
 [compat]
 Aqua = "0.8"
 BenchmarkTools = "1"
-CTBase = "0.27"
+CTBase = "0.27, 0.28"
 DocStringExtensions = "0.9"
 JET = "0.9, 0.11"
 JLD2 = "0.6"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,7 +11,7 @@ MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
-CTBase = "0.27"
+CTBase = "0.27, 0.28"
 Documenter = "1"
 DocumenterInterLinks = "1"
 DocumenterVitepress = "0.3"


### PR DESCRIPTION
## Summary

- **CTBase compat widened** from `0.27` to `0.27, 0.28` in both `Project.toml` and `docs/Project.toml`
- **Version bump** `0.15.2-beta` → `0.15.3-beta`
- **No source changes required** — CTModels is source-compatible with CTBase 0.28
- **No breaking changes** — full backward compatibility with CTBase 0.27

## Changes

- `Project.toml`: CTBase compat `0.27` → `0.27, 0.28`, version `0.15.3-beta`
- `docs/Project.toml`: CTBase compat `0.27` → `0.27, 0.28`
- `CHANGELOG.md`: added `[0.15.3-beta]` entry
- `BREAKING.md`: added `[0.15.3-beta]` compatibility note (no breaking changes)