### PR TITLE
ci: stop label-gated workflows from re-triggering on every subsequent label

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   call:
-    if: contains(github.event.pull_request.labels.*.name, 'run breakage')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'run breakage') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run breakage'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,15 @@ on:
     
 jobs:
   call:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run ci')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       runs_on: '["ubuntu-latest","macos-latest"]'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,7 +11,15 @@ on:
   
 jobs:
   call:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run documentation')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run documentation') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run documentation'))
     uses: control-toolbox/CTActions/.github/workflows/documentation.yml@main
     with:
       use_ct_registry: true


### PR DESCRIPTION
## Root cause

GitHub fires a separate `pull_request` event of type `labeled` for **each label added individually**, and the job's `if` condition is re-evaluated against the PR's *current full label set* every time — not just the label that triggered this specific event.

So if a PR gets labels `run ci`, then `run documentation`, then `run breakage` added one after another, the `run ci` job (already matched by the first label) gets needlessly re-run on the second and third label-add events too, since its label is still present in the full set. Same for any job matched earlier. This wastes CI runs and clutters the Actions tab.

## Fix

For the `labeled` event specifically, check `github.event.label.name` against the job's own gating label; for every other trigger type (`synchronize`/`reopened`/`push`), keep the existing full-label-set check unchanged.

## Files changed

- `.github/workflows/CI.yml` — job `call`, label `run ci`
- `.github/workflows/Documentation.yml` — job `call`, label `run documentation`
- `.github/workflows/Breakage.yml` — job `call`, label `run breakage` (PR-only job, no `github.event_name != 'pull_request'` prefix)

All other workflow files under `.github/workflows/` were checked (`grep -rl "labeled" .github/workflows/`) and do not use this pattern (CompatHelper, Coverage, Formatter, SpellCheck, TagBot, UpdateReadme, AutoAssign, AddToProject, etc.), so they were left untouched.

## Validation

All three edited YAML files parse correctly via `python3 -c "import yaml; ..."`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)