### PR TITLE
Enforce Handbook tenet 2: using, never import

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -596,7 +596,7 @@ The InitialGuess module has been renamed to `Init` for better API ergonomics and
 using CTModels.InitialGuess
 
 # After (0.9.0-beta)
-using CTModels.Init
+using CTModels: Init
 ```
 
 ##### Type Names
@@ -620,7 +620,7 @@ using CTModels.InitialGuess
 pre_init = CTModels.OptimalControlPreInit(state=0.1, control=0.2)
 
 # After
-using CTModels.Init
+using CTModels: Init
 pre_init = CTModels.PreInitialGuess(state=0.1, control=0.2)
 ```
 
@@ -695,12 +695,12 @@ Major refactoring where several modules have been moved from CTModels to the new
 #### Moved Modules
 The following modules are no longer part of CTModels and must be imported from CTSolvers:
 
-- **Options** → `using CTSolvers.Options`
-- **Strategies** → `using CTSolvers.Strategies` 
-- **Orchestration** → `using CTSolvers.Orchestration`
-- **Optimization** → `using CTSolvers.Optimization`
-- **Modelers** → `using CTSolvers.Modelers`
-- **DOCP** → `using CTSolvers.DOCP`
+- **Options** → `using CTSolvers: Options`
+- **Strategies** → `using CTSolvers: Strategies` 
+- **Orchestration** → `using CTSolvers: Orchestration`
+- **Optimization** → `using CTSolvers: Optimization`
+- **Modelers** → `using CTSolvers: Modelers`
+- **DOCP** → `using CTSolvers: DOCP`
 
 #### Migration Guide
 
@@ -715,9 +715,9 @@ using CTModels.Optimization
 ##### After (CTModels ≥ 0.8.0)
 ```julia
 using CTModels
-using CTSolvers.Options
-using CTSolvers.Strategies  
-using CTSolvers.Optimization
+using CTSolvers: Options
+using CTSolvers: Strategies  
+using CTSolvers: Optimization
 ```
 
 #### Specific Changes
@@ -729,7 +729,7 @@ using CTModels.Options
 opt = CTModels.OptionValue(100, :user)
 
 # After  
-using CTSolvers.Options
+using CTSolvers: Options
 opt = CTSolvers.OptionValue(100, :user)
 ```
 
@@ -740,7 +740,7 @@ using CTModels.Strategies
 strategy = CTModels.DirectStrategy()
 
 # After
-using CTSolvers.Strategies
+using CTSolvers: Strategies
 strategy = CTSolvers.DirectStrategy()
 ```
 
@@ -751,7 +751,7 @@ using CTModels.Modelers
 modeler = CTModels.ADNLPModeler()
 
 # After
-using CTSolvers.Modelers
+using CTSolvers: Modelers
 modeler = CTSolvers.ADNLPModeler()
 ```
 
@@ -762,7 +762,7 @@ using CTModels.DOCP
 docp = CTModels.DiscretizedOptimalControlProblem(...)
 
 # After
-using CTSolvers.DOCP
+using CTSolvers: DOCP
 docp = CTSolvers.DiscretizedOptimalControlProblem(...)
 )
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,7 +883,7 @@ using CTModels.InitialGuess
 pre = CTModels.OptimalControlPreInit(...)
 
 # After
-using CTModels.Init  
+using CTModels: Init  
 pre = CTModels.PreInitialGuess(...)
 ```
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -11,7 +11,7 @@ CTModels.jl is typically installed as a dependency of another package in the eco
 To install it directly:
 
 ```julia
-import Pkg
+using Pkg: Pkg
 Pkg.add("CTModels")
 ```
 

--- a/docs/src/initial_guess/validation.md
+++ b/docs/src/initial_guess/validation.md
@@ -11,7 +11,7 @@ check against the model. The check can also be invoked on its own with
 
 ```@example val
 using CTModels
-import CTBase
+using CTBase: CTBase
 
 pre = CTModels.PreModel()
 CTModels.variable!(pre, 0)

--- a/docs/src/model/components.md
+++ b/docs/src/model/components.md
@@ -17,7 +17,7 @@ with inconsistent dimensions, raises a structured exception.
 
 ```@example components
 using CTModels
-import CTBase
+using CTBase: CTBase
 pre = CTModels.PreModel()
 nothing # hide
 ```

--- a/ext/CTModelsJLD.jl
+++ b/ext/CTModelsJLD.jl
@@ -7,7 +7,7 @@ Adds methods for [`CTModels.export_ocp_solution`](@ref) and
 """
 module CTModelsJLD
 
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
 using CTModels: CTModels
 using JLD2: JLD2

--- a/ext/CTModelsJSON.jl
+++ b/ext/CTModelsJSON.jl
@@ -7,9 +7,9 @@ Adds methods for [`CTModels.export_ocp_solution`](@ref) and
 """
 module CTModelsJSON
 
-import CTBase.Core
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
+using CTBase: Core
 using CTModels: CTModels
 using JSON3: JSON3
 

--- a/ext/CTModelsPlots.jl
+++ b/ext/CTModelsPlots.jl
@@ -8,10 +8,9 @@ and rendering to the generic `CTBase.Plotting` engine.
 """
 module CTModelsPlots
 
-import CTBase.Plotting
-import CTBase.Exceptions
-import DocStringExtensions: TYPEDSIGNATURES
+using DocStringExtensions: TYPEDSIGNATURES
 
+using CTBase: Plotting, Exceptions
 using CTModels: CTModels
 using Plots: Plots
 

--- a/src/Building/Building.jl
+++ b/src/Building/Building.jl
@@ -20,12 +20,10 @@ See also: [`CTModels.Components`](@ref), [`CTModels.Models`](@ref).
 """
 module Building
 
-import CTBase.Core
-import CTBase.Exceptions
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
-import Parameters: @with_kw
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using Parameters: @with_kw
 
-using CTBase: CTBase
+using CTBase: CTBase, Core, Exceptions
 using MLStyle: MLStyle
 
 # Foundational types and type aliases

--- a/src/Building/build.jl
+++ b/src/Building/build.jl
@@ -170,7 +170,7 @@ This function processes a dictionary where each entry defines a constraint with 
 
 # Example
 ```julia
-using CTModels.Building
+using CTModels: Building
 using OrderedCollections
 
 f1(t, x, u, v) = x[1]
@@ -547,7 +547,7 @@ a fully validated [`CTModels.Models.Model`](@ref) from a [`CTModels.Building.Pre
 
 # Example
 ```julia
-using CTModels.Building
+using CTModels: Building
 
 # Create and configure a pre-model
 pre_ocp = PreModel()

--- a/src/Building/constraint_composers.jl
+++ b/src/Building/constraint_composers.jl
@@ -26,7 +26,7 @@ inside [`CTModels.Building.build`](@ref) in `build.jl`.
 # Examples
 
 ```julia
-using CTModels.Building
+using CTModels: Building
 
 f1!(r, t, x, u, v) = (r[1] = x[1] + u[1])
 f2!(r, t, x, u, v) = (r[1] = x[2])

--- a/src/Components/Components.jl
+++ b/src/Components/Components.jl
@@ -26,10 +26,9 @@ See also: [`CTModels.Building`](@ref), [`CTModels.Models`](@ref).
 """
 module Components
 
-import CTBase.Core
-import CTBase.Exceptions
-import CTBase.Traits: TimeDependence, Autonomous, NonAutonomous
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using CTBase: CTBase, Core, Exceptions
+using CTBase: TimeDependence, Autonomous, NonAutonomous
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using OrderedCollections: OrderedCollections
 
 include(joinpath(@__DIR__, "functors.jl"))

--- a/src/Display/Display.jl
+++ b/src/Display/Display.jl
@@ -36,11 +36,9 @@ See also: `CTModels.Components`, `CTModels.Models`, `CTModels.Building`, `CTMode
 """
 module Display
 
-import CTBase.Exceptions
-import CTBase.Core
-import DocStringExtensions: TYPEDSIGNATURES
+using DocStringExtensions: TYPEDSIGNATURES
 
-using CTBase: CTBase
+using CTBase: CTBase, Exceptions, Core
 using MLStyle: MLStyle
 using RecipesBase: RecipesBase
 using MacroTools: MacroTools

--- a/src/Init/Init.jl
+++ b/src/Init/Init.jl
@@ -45,12 +45,9 @@ See also: [`CTModels.Components`](@ref), [`CTModels.Models`](@ref), [`CTModels.S
 """
 module Init
 
-import CTBase.Core
-import CTBase.Interpolation
-import CTBase.Exceptions
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
-using CTBase: CTBase
+using CTBase: CTBase, Core, Interpolation, Exceptions
 
 using ..Components
 using ..Models

--- a/src/Init/init_functors.jl
+++ b/src/Init/init_functors.jl
@@ -101,7 +101,7 @@ Replaces the anonymous closure `t -> begin … end` (57 lines) produced inside
 # Examples
 
 ```julia
-using CTModels.Init
+using CTModels: Init
 
 base = t -> [0.0, 0.0]
 comps = Dict{Int,Function}(2 => t -> sin(t))

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -30,13 +30,11 @@ See also: [`CTModels.Components`](@ref), [`CTModels.Building`](@ref), [`CTModels
 """
 module Models
 
-import CTBase.Core
-import CTBase.Exceptions
-import CTBase.Traits
+using CTBase: CTBase, Core, Exceptions, Traits
 # Time/variable/control-dependence predicates are generic functions owned by
 # CTBase.Traits; CTModels only provides the `Model` trait contract (see model.jl)
 # and re-exports them.
-import CTBase.Traits:
+using CTBase:
     is_autonomous,
     is_nonautonomous,
     is_variable,
@@ -44,7 +42,7 @@ import CTBase.Traits:
     has_variable,
     is_control_free,
     has_control
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
 using ..Components
 

--- a/src/Serialization/Serialization.jl
+++ b/src/Serialization/Serialization.jl
@@ -36,10 +36,9 @@ See also: [`CTModels.Serialization.export_ocp_solution`](@ref),
 """
 module Serialization
 
-import CTBase.Exceptions
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
-using CTBase: CTBase
+using CTBase: CTBase, Exceptions
 
 using ..Components
 using ..Models

--- a/src/Solutions/Solutions.jl
+++ b/src/Solutions/Solutions.jl
@@ -51,12 +51,9 @@ Exported functions:
 """
 module Solutions
 
-import CTBase.Core
-import CTBase.Interpolation
-import CTBase.Exceptions
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 
-using CTBase: CTBase
+using CTBase: CTBase, Core, Interpolation, Exceptions
 
 # Foundational types and type aliases
 using ..Components
@@ -65,7 +62,7 @@ using ..Components
 using ..Models
 
 # Private defaults used by build_solution and its accessors
-import ..Building:
+using ..Building:
     __constraints,
     __control_interpolation,
     __time_grid_default_component,

--- a/test/suite/building/test_building_exceptions.jl
+++ b/test/suite/building/test_building_exceptions.jl
@@ -1,9 +1,9 @@
 module TestBuildingExceptions
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_constraints.jl
+++ b/test/suite/building/test_constraints.jl
@@ -1,10 +1,10 @@
 module TestOCPConstraints
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Models: Models
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_control.jl
+++ b/test/suite/building/test_control.jl
@@ -1,9 +1,9 @@
 module TestOCPControl
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_control_zero.jl
+++ b/test/suite/building/test_control_zero.jl
@@ -1,16 +1,16 @@
 module TestControlZero
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
-import CTModels.Init: Init
-import CTModels.Serialization: Serialization
-import Plots: Plots
-import JLD2: JLD2
-import JSON3: JSON3
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
+using CTModels: Models
+using CTModels: Solutions
+using CTModels: Init
+using CTModels: Serialization
+using Plots: Plots
+using JLD2: JLD2
+using JSON3: JSON3
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_dedup.jl
+++ b/test/suite/building/test_dedup.jl
@@ -1,9 +1,9 @@
 module TestBuildingDedup
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_defaults.jl
+++ b/test/suite/building/test_defaults.jl
@@ -1,8 +1,8 @@
 module TestOCPDefaults
 
-import Test: Test
-import CTBase: CTBase
-import CTModels.Building: Building
+using Test: Test
+using CTBase: CTBase
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_definition.jl
+++ b/test/suite/building/test_definition.jl
@@ -1,9 +1,9 @@
 module TestOCPDefinition
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Building: Building
+using Test: Test
+using CTModels: Components
+using CTModels: Models
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_dynamics.jl
+++ b/test/suite/building/test_dynamics.jl
@@ -1,8 +1,8 @@
 module TestOCPDynamics
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_name_conflicts_integration.jl
+++ b/test/suite/building/test_name_conflicts_integration.jl
@@ -1,9 +1,9 @@
 module TestNameConflictsIntegrationSimple
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_name_validation.jl
+++ b/test/suite/building/test_name_validation.jl
@@ -1,8 +1,8 @@
 module TestNameValidation
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_objective.jl
+++ b/test/suite/building/test_objective.jl
@@ -1,9 +1,9 @@
 module TestOCPObjective
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_state.jl
+++ b/test/suite/building/test_state.jl
@@ -1,9 +1,9 @@
 module TestOCPState
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_time_dependence.jl
+++ b/test/suite/building/test_time_dependence.jl
@@ -1,8 +1,8 @@
 module TestOCPTimeDependence
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_times.jl
+++ b/test/suite/building/test_times.jl
@@ -1,9 +1,9 @@
 module TestOCPTimes
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/building/test_variable.jl
+++ b/test/suite/building/test_variable.jl
@@ -1,9 +1,9 @@
 module TestOCPVariable
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/components/test_components.jl
+++ b/test/suite/components/test_components.jl
@@ -1,7 +1,7 @@
 module TestComponents
 
-import Test: Test
-import CTModels.Components: Components
+using Test: Test
+using CTModels: Components
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/components/test_contracts.jl
+++ b/test/suite/components/test_contracts.jl
@@ -1,9 +1,9 @@
 module TestContracts
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Models: Models
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/components/test_model_types.jl
+++ b/test/suite/components/test_model_types.jl
@@ -1,9 +1,9 @@
 module TestModelTypes
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Building: Building
+using Test: Test
+using CTModels: Components
+using CTModels: Models
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/display/test_print.jl
+++ b/test/suite/display/test_print.jl
@@ -1,9 +1,9 @@
 module TestPrint
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Display: Display
+using Test: Test
+using CTModels: Components
+using CTModels: Building
+using CTModels: Display
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/extensions/test_plot.jl
+++ b/test/suite/extensions/test_plot.jl
@@ -1,15 +1,15 @@
 module TestPlot
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import Plots: Plots
-import CTModels: CTModels
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTBase: Exceptions
+using Plots: Plots
+using CTModels: CTModels
+using CTModels: Components
+using CTModels: Models
+using CTModels: Solutions
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/extensions/test_plot_reference.jl
+++ b/test/suite/extensions/test_plot_reference.jl
@@ -28,13 +28,13 @@ module TestPlotReference
 #     a CTDirect/Ipopt dependency (closed-form solution via `build_solution`).
 # ==============================================================================
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import Plots: Plots
-import CTModels: CTModels
+using Test: Test
+using CTBase: Exceptions
+using Plots: Plots
+using CTModels: CTModels
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_api.jl
+++ b/test/suite/init/test_initial_guess_api.jl
@@ -1,12 +1,12 @@
 module TestInitialGuessAPI
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Models: Models
-import CTModels.Init: Init
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Models
+using CTModels: Init
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_builders.jl
+++ b/test/suite/init/test_initial_guess_builders.jl
@@ -1,9 +1,9 @@
 module TestInitialGuessBuilders
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Models: Models
-import CTModels.Init: Init
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Models
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_control.jl
+++ b/test/suite/init/test_initial_guess_control.jl
@@ -1,9 +1,9 @@
 module TestInitialGuessControl
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Models: Models
-import CTModels.Init: Init
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Models
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_integration.jl
+++ b/test/suite/init/test_initial_guess_integration.jl
@@ -1,12 +1,12 @@
 module TestInitialGuessIntegration
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Models: Models
-import CTModels.Init: Init
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Models
+using CTModels: Init
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_show.jl
+++ b/test/suite/init/test_initial_guess_show.jl
@@ -1,7 +1,7 @@
 module TestInitialGuessShow
 
-import Test: Test
-import CTModels.Init: Init
+using Test: Test
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_state.jl
+++ b/test/suite/init/test_initial_guess_state.jl
@@ -1,10 +1,10 @@
 module TestInitialGuessState
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Init: Init
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Models
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_types.jl
+++ b/test/suite/init/test_initial_guess_types.jl
@@ -1,7 +1,7 @@
 module TestInitialGuessTypes
 
-import Test: Test
-import CTModels.Init: Init
+using Test: Test
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_utils.jl
+++ b/test/suite/init/test_initial_guess_utils.jl
@@ -1,9 +1,9 @@
 module TestInitialGuessUtils
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Init: Init
+using Test: Test
+using CTModels: Components
+using CTModels: Models
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_validation.jl
+++ b/test/suite/init/test_initial_guess_validation.jl
@@ -1,14 +1,14 @@
 module TestInitialGuessValidation
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
-import CTModels.Init: Init
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Models
+using CTModels: Solutions
+using CTModels: Init
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/init/test_initial_guess_variable.jl
+++ b/test/suite/init/test_initial_guess_variable.jl
@@ -1,10 +1,10 @@
 module TestInitialGuessVariable
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Init: Init
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Models
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/integration/test_ocp.jl
+++ b/test/suite/integration/test_ocp.jl
@@ -1,10 +1,10 @@
 module TestOCP
 
-import Test: Test
-import CTBase: CTBase
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Building: Building
+using Test: Test
+using CTBase: CTBase
+using CTModels: Components
+using CTModels: Models
+using CTModels: Building
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/meta/test_CTModels.jl
+++ b/test/suite/meta/test_CTModels.jl
@@ -1,12 +1,12 @@
 module TestCTModelsTop
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels: CTModels
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
-import CTModels.Serialization: Serialization
+using Test: Test
+using CTBase: Exceptions
+using CTModels: CTModels
+using CTModels: Components
+using CTModels: Models
+using CTModels: Solutions
+using CTModels: Serialization
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/meta/test_code_quality.jl
+++ b/test/suite/meta/test_code_quality.jl
@@ -1,12 +1,12 @@
 module TestCodeQuality
 
-import Test: Test
-import Aqua: Aqua
-import JET: JET
-import CTModels: CTModels
-import CTModels.Components: Components
-import CTModels.Solutions: Solutions
-import CTModels.Models: Models
+using Test: Test
+using Aqua: Aqua
+using JET: JET
+using CTModels: CTModels
+using CTModels: Components
+using CTModels: Solutions
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/meta/test_no_import.jl
+++ b/test/suite/meta/test_no_import.jl
@@ -1,0 +1,48 @@
+"""
+Regression guard for the Handbook rule "using, never import" (tenet 2,
+`philosophy/modules.md#using-never-import`): flags any tracked `.jl` or `.md`
+file that still uses the `import` keyword, or the forbidden dotted
+`using Pkg.Sub` form (the canonical spelling is `using Pkg: Sub`).
+"""
+
+module TestNoImport
+
+using Test: Test
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+const IMPORT_RE = r"^\s*import\b"
+const DOTTED_USING_RE = r"^\s*using\s+[A-Za-z_]\w*\.[A-Za-z_]"
+
+# BREAKING.md and CHANGELOG.md quote `using CTModels.InitialGuess`, `using
+# CTModels.Options`, etc. verbatim as the real, historical pre-migration API
+# (the "Before" snippets in their migration guides) — that's a historical
+# fact, not a current-convention violation, so both files are exempt from the
+# dotted-using check.
+const DOTTED_USING_EXEMPT = ("BREAKING.md", "CHANGELOG.md")
+
+function test_no_import()
+    Test.@testset "No `import` / no dotted `using Pkg.Sub` (Handbook tenet 2)" verbose = VERBOSE showtiming =
+        SHOWTIMING begin
+        repo_root = joinpath(@__DIR__, "..", "..", "..")
+        tracked = filter(
+            f -> endswith(f, ".jl") || endswith(f, ".md"),
+            readlines(Cmd(`git ls-files`; dir=repo_root)),
+        )
+        for relpath in tracked
+            path = joinpath(repo_root, relpath)
+            check_dotted = !(basename(relpath) in DOTTED_USING_EXEMPT)
+            for line in eachline(path)
+                Test.@test !occursin(IMPORT_RE, line)
+                if check_dotted
+                    Test.@test !occursin(DOTTED_USING_RE, line)
+                end
+            end
+        end
+    end
+end
+
+end # module
+
+test_no_import() = TestNoImport.test_no_import()

--- a/test/suite/meta/test_performance.jl
+++ b/test/suite/meta/test_performance.jl
@@ -34,13 +34,13 @@ module TestPerformance
 
 using Test: Test
 using BenchmarkTools: BenchmarkTools
-import CTBase: CTBase
-import CTBase.Interpolation
-import CTBase.Traits
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Solutions: Solutions
-import CTModels.Models: Models
+using CTBase: CTBase
+using CTBase: Interpolation
+using CTBase: Traits
+using CTModels: Components
+using CTModels: Building
+using CTModels: Solutions
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/meta/test_types.jl
+++ b/test/suite/meta/test_types.jl
@@ -1,11 +1,11 @@
 module TestTypes
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
-import CTModels.Building: Building
-import CTModels.Init: Init
+using Test: Test
+using CTModels: Components
+using CTModels: Models
+using CTModels: Solutions
+using CTModels: Building
+using CTModels: Init
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/meta/test_where_bounds.jl
+++ b/test/suite/meta/test_where_bounds.jl
@@ -17,10 +17,10 @@ tightened, that the induced `TypeVar`'s upper bound is the intended bound and no
 
 module TestWhereBounds
 
-import Test: Test
-import CTBase.Traits: Traits
-import CTModels.Components: Components
-import CTModels.Models: Models
+using Test: Test
+using CTBase: Traits
+using CTModels: Components
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/models/test_build_examodel.jl
+++ b/test/suite/models/test_build_examodel.jl
@@ -1,9 +1,9 @@
 module TestBuildExamodel
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Building: Building
-import CTModels.Models: Models
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Building
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/models/test_model.jl
+++ b/test/suite/models/test_model.jl
@@ -1,11 +1,11 @@
 module TestOCPModel
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTBase.Traits: Traits
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Models: Models
+using Test: Test
+using CTBase: Exceptions
+using CTBase: Traits
+using CTModels: Components
+using CTModels: Building
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/models/test_variable_control_checks.jl
+++ b/test/suite/models/test_variable_control_checks.jl
@@ -1,9 +1,9 @@
 module TestVariableControlChecks
 
-import Test: Test
-import CTBase.Traits: Traits
-import CTModels.Building: Building
-import CTModels.Models: Models
+using Test: Test
+using CTBase: Traits
+using CTModels: Building
+using CTModels: Models
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/serialization/test_export_import.jl
+++ b/test/suite/serialization/test_export_import.jl
@@ -1,15 +1,15 @@
 module TestExportImport
 
-import Test: Test
-import JLD2: JLD2
-import JSON3: JSON3
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
-import CTModels.Serialization: Serialization
+using Test: Test
+using JLD2: JLD2
+using JSON3: JSON3
+using CTModels: Components
+using CTModels: Models
+using CTModels: Solutions
+using CTModels: Serialization
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/serialization/test_ext_exceptions.jl
+++ b/test/suite/serialization/test_ext_exceptions.jl
@@ -1,14 +1,14 @@
 module TestExtExceptions
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import RecipesBase: RecipesBase
-import CTModels.Serialization: Serialization
-import CTModels.Solutions: Solutions
-import CTModels.Models: Models
+using Test: Test
+using CTBase: Exceptions
+using RecipesBase: RecipesBase
+using CTModels: Serialization
+using CTModels: Solutions
+using CTModels: Models
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/serialization/test_multi_grids.jl
+++ b/test/suite/serialization/test_multi_grids.jl
@@ -1,16 +1,16 @@
 module TestMultiGrids
 
-import Test: Test
-import JLD2: JLD2
-import JSON3: JSON3
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
-import CTModels.Serialization: Serialization
+using Test: Test
+using JLD2: JLD2
+using JSON3: JSON3
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Models
+using CTModels: Solutions
+using CTModels: Serialization
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/serialization/test_serialization_units.jl
+++ b/test/suite/serialization/test_serialization_units.jl
@@ -1,13 +1,13 @@
 module TestSerializationUnits
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Solutions: Solutions
-import CTModels.Serialization: Serialization
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Solutions
+using CTModels: Serialization
 
 include(joinpath("..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_discretization_utils.jl
+++ b/test/suite/solutions/test_discretization_utils.jl
@@ -1,7 +1,7 @@
 module TestDiscretizationUtils
 
-import Test: Test
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_dual_model.jl
+++ b/test/suite/solutions/test_dual_model.jl
@@ -1,10 +1,10 @@
 module TestOCPDualModel
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Building: Building
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Building
+using CTModels: Models
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_empty_dual_model.jl
+++ b/test/suite/solutions/test_empty_dual_model.jl
@@ -1,10 +1,10 @@
 module TestOCPEmptyDualModel
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Building: Building
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Building
+using CTModels: Models
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_grid_extension.jl
+++ b/test/suite/solutions/test_grid_extension.jl
@@ -1,8 +1,8 @@
 module TestGridExtension
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_interpolation_helpers.jl
+++ b/test/suite/solutions/test_interpolation_helpers.jl
@@ -1,11 +1,11 @@
 module TestInterpolationHelpers
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
+using CTModels: Models
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_solution.jl
+++ b/test/suite/solutions/test_solution.jl
@@ -1,10 +1,10 @@
 module TestOCPSolution
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTModels: Components
+using CTModels: Building
+using CTModels: Models
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_solution_multi_grids.jl
+++ b/test/suite/solutions/test_solution_multi_grids.jl
@@ -1,10 +1,10 @@
 module TestSolutionMultiGrids
 
-import Test: Test
-import CTBase.Exceptions: Exceptions
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTBase: Exceptions
+using CTModels: Components
+using CTModels: Building
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_solution_show.jl
+++ b/test/suite/solutions/test_solution_show.jl
@@ -1,10 +1,10 @@
 module TestSolutionShow
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Building: Building
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTModels: Components
+using CTModels: Building
+using CTModels: Models
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solutions/test_solution_types.jl
+++ b/test/suite/solutions/test_solution_types.jl
@@ -1,9 +1,9 @@
 module TestSolutionTypes
 
-import Test: Test
-import CTModels.Components: Components
-import CTModels.Models: Models
-import CTModels.Solutions: Solutions
+using Test: Test
+using CTModels: Components
+using CTModels: Models
+using CTModels: Solutions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true


### PR DESCRIPTION
## Summary
- Replace all `import` statements with `using` across `src/`, `ext/`, `test/`, and docs (`docs/src/*.md`, `BREAKING.md`, `CHANGELOG.md`), per the control-toolbox Handbook tenet 2 (`philosophy/modules.md#using-never-import`).
- Fix the forbidden dotted `using Pkg.Sub` form → `using Pkg: Sub`, everywhere except historical "Before" migration snippets in `BREAKING.md`/`CHANGELOG.md`, which quote a past API verbatim and are intentionally left untouched.
- Add a regression-guard test (`test/suite/meta/test_no_import.jl`, adapted from [CTLie's version](https://github.com/control-toolbox/CTLie.jl/blob/main/test/suite/meta/test_no_import.jl)) that scans every tracked `.jl`/`.md` file so this can't silently regress.

No behavior change — pure syntax substitution, same symbols brought into scope.

Closes #384.

## Test plan
- [x] `julia --project=@. -e 'using CTModels'` — package loads cleanly
- [x] Full test suite (`Pkg.test()`) — 70,315 tests pass, including the new `test_no_import.jl` guard and the existing Aqua/JET code-quality checks
- [x] Manual diff review of `BREAKING.md`/`CHANGELOG.md` to confirm only "After"/current-usage snippets were touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)