### PR TITLE
Fix import_ocp_solution for a solution with exactly one variable

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,6 +4,18 @@
 
 This document describes breaking changes in CTModels releases and how to migrate your code.
 
+## [0.16.2] - 2026-08-16
+
+### No Breaking Changes
+
+Fixes `import_ocp_solution` for a solution whose OCP has exactly one variable
+([OptimalControl.jl#857](https://github.com/control-toolbox/OptimalControl.jl/issues/857)).
+`Components.variable(sol)` was already a scalar for a 1-D variable; only the on-disk
+JLD2/JSON format and the importer's robustness changed — exports always write a
+`Vector{Float64}` now, and imports accept both the new vector format and the old
+(broken) scalar format, so files exported before this fix remain importable without
+re-exporting. No API signature changed.
+
 ## [0.16.1] - 2026-08-01
 
 ### No Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-08-16
+
+### 🐛 Fixed
+
+- **`import_ocp_solution` failed for a solution whose OCP has exactly one variable.**
+  `Components.variable(sol)` returns a `Float64` (not a length-1 vector) when
+  `variable_dimension(ocp) == 1`, per the "1-D is a scalar" convention. This scalar was
+  previously written raw into JLD2/JSON exports, and `import_ocp_solution` then failed
+  with `MethodError: no method matching Vector{Float64}(::Float64)` on re-import
+  ([OptimalControl.jl#857](https://github.com/control-toolbox/OptimalControl.jl/issues/857)).
+  `_serialize_solution` now normalizes `"variable"` to a `Vector{Float64}` on the wire
+  (`Solutions._as_vector`), and both importers (`Serialization._extract_time_vector`,
+  and the JSON extension) accept the scalar format from already-exported files as well,
+  so files exported before this fix remain importable without re-exporting.
+- **No breaking changes**: `variable(sol)` was already a scalar for a 1-D variable;
+  only the on-disk format and import robustness changed. See [BREAKING.md](BREAKING.md).
+
 ## [0.16.1] - 2026-08-01
 
 ### 📚 Documentation

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/ext/CTModelsJSON.jl
+++ b/ext/CTModelsJSON.jl
@@ -305,7 +305,7 @@ function CTModels.import_ocp_solution(
         "state" => _json_to_matrix(blob["state"]),
         "control" => _json_to_matrix(blob["control"]),
         "costate" => _json_to_matrix(blob["costate"]),
-        "variable" => Vector{Float64}(blob.variable),
+        "variable" => CTModels.Serialization._extract_time_vector(blob.variable),
         "path_constraints_dual" => _json_to_optional_matrix(blob["path_constraints_dual"]),
         "boundary_constraints_dual" => isnothing(bcd) ? nothing : Vector{Float64}(bcd),
         "state_constraints_lb_dual" =>

--- a/src/Serialization/reconstruction_helpers.jl
+++ b/src/Serialization/reconstruction_helpers.jl
@@ -125,14 +125,16 @@ $(TYPEDSIGNATURES)
 Extract time vector from various data formats.
 
 # Arguments
-- `time_data`: Time data in various formats (Vector, Matrix, etc.)
+- `time_data`: Time data in various formats (Vector, Matrix, scalar, etc.)
 
 # Returns
 - `Vector{Float64}`: Time vector
 
 # Notes
-- Handles both Vector{Float64} and Matrix{Float64} (single column) formats
-- Used by JSON and JLD2 importers to normalize time grid data
+- Handles Vector{Float64}, Matrix{Float64} (single column) and scalar `Real` formats
+- Used by JSON and JLD2 importers to normalize time grid data, and to normalize the
+  `"variable"` field, which is serialized as a scalar when `variable_dimension(ocp) == 1`
+  (per the "1-D is a scalar" convention, see [`CTModels.Components.variable`](@extref))
 
 See also: [`CTModels.Serialization._reconstruct_solution_from_data`](@extref).
 """
@@ -141,6 +143,8 @@ function _extract_time_vector(time_data)
         return time_data
     elseif time_data isa Matrix{Float64}
         return vec(time_data)
+    elseif time_data isa Real
+        return [Float64(time_data)]
     else
         return Vector{Float64}(time_data)
     end

--- a/src/Solutions/build_solution.jl
+++ b/src/Solutions/build_solution.jl
@@ -1775,7 +1775,7 @@ function _discretize_all_components(
         "control" => _discretize_function(control(sol), T_control, dim_u),
         "control_interpolation" => string(control_interpolation(sol)),
         "costate" => _discretize_function(costate(sol), T_costate, dim_x),
-        "variable" => variable(sol),
+        "variable" => _as_vector(variable(sol)),
         "objective" => objective(sol),
         "path_constraints_dual" => _discretize_dual(
             path_constraints_dual(sol), T_path, dim_path_constraints_nl(sol)

--- a/src/Solutions/discretization_utils.jl
+++ b/src/Solutions/discretization_utils.jl
@@ -87,3 +87,20 @@ See also: [`CTModels.Solutions._discretize_function`](@extref).
 function _discretize_dual(dual_func::Union{Function,Nothing}, T, dim::Int=-1)
     return isnothing(dual_func) ? nothing : _discretize_function(dual_func, T, dim)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Normalize a time-independent solution field (currently only `variable`) to a
+`Vector{Float64}` for serialization.
+
+`Components.variable(sol)` follows the "1-D is a scalar" convention: it returns a bare
+`Number` when `variable_dimension(ocp) == 1`, and a `Vector{Float64}` otherwise. Unlike
+`state`/`control`/`costate`, this field is not run through `_discretize_function` (it is
+time-independent), so without this normalization a scalar would leak into the serialized
+data untouched.
+
+See also: [`CTModels.Solutions._discretize_all_components`](@extref).
+"""
+_as_vector(v::ctNumber)::Vector{Float64} = [Float64(v)]
+_as_vector(v::ctVector)::Vector{Float64} = Vector{Float64}(v)

--- a/test/suite/serialization/test_serialization_units.jl
+++ b/test/suite/serialization/test_serialization_units.jl
@@ -287,6 +287,70 @@ function test_serialization_units()
 
             isfile("dual_functor_jld_test.jld2") && rm("dual_functor_jld_test.jld2")
         end
+
+        # ==============================================================================
+        # C.6 — Regression: scalar variable (variable_dimension == 1)
+        #
+        # https://github.com/control-toolbox/OptimalControl.jl/issues/857
+        # `variable(sol)` follows the "1-D is a scalar" convention and returns a bare
+        # `Float64` when variable_dimension(ocp) == 1 (e.g. a free final time). This
+        # scalar must be normalized to a Vector{Float64} on export, and any legacy
+        # scalar already on disk must still be readable on import.
+        # ==============================================================================
+
+        Test.@testset "_serialize_solution: variable is always a Vector{Float64} (dim 1)" begin
+            _, sol = TestProblems.solution_example_free_final_time()
+            Test.@test Components.variable(sol) isa Float64
+
+            data = Solutions._serialize_solution(sol)
+            Test.@test data["variable"] isa Vector{Float64}
+            Test.@test data["variable"] == [Components.variable(sol)]
+        end
+
+        Test.@testset "Round-trip: scalar variable (dim 1, JLD2)" begin
+            ocp, sol = TestProblems.solution_example_free_final_time()
+
+            Serialization.export_ocp_solution(
+                sol; filename="scalar_variable_test", format=:JLD
+            )
+            sol2 = Serialization.import_ocp_solution(
+                ocp; filename="scalar_variable_test", format=:JLD
+            )
+
+            Test.@test Components.variable(sol2) isa Float64
+            Test.@test Components.variable(sol2) ≈ Components.variable(sol) atol = 1e-10
+
+            isfile("scalar_variable_test.jld2") && rm("scalar_variable_test.jld2")
+        end
+
+        Test.@testset "Round-trip: scalar variable (dim 1, JSON)" begin
+            ocp, sol = TestProblems.solution_example_free_final_time()
+
+            Serialization.export_ocp_solution(
+                sol; filename="scalar_variable_test", format=:JSON
+            )
+            sol2 = Serialization.import_ocp_solution(
+                ocp; filename="scalar_variable_test", format=:JSON
+            )
+
+            Test.@test Components.variable(sol2) isa Float64
+            Test.@test Components.variable(sol2) ≈ Components.variable(sol) atol = 1e-10
+
+            isfile("scalar_variable_test.json") && rm("scalar_variable_test.json")
+        end
+
+        Test.@testset "_reconstruct_solution_from_data: legacy scalar variable (backward compat)" begin
+            ocp, sol = TestProblems.solution_example_free_final_time()
+            data = Solutions._serialize_solution(sol)
+
+            # Simulate a file exported before the fix, where "variable" was a bare
+            # scalar Float64 instead of a Vector{Float64}.
+            data["variable"] = Components.variable(sol)
+
+            sol2 = Serialization._reconstruct_solution_from_data(ocp, data)
+            Test.@test Components.variable(sol2) isa Float64
+            Test.@test Components.variable(sol2) ≈ Components.variable(sol) atol = 1e-10
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

Fixes control-toolbox/OptimalControl.jl#857.

`Components.variable(sol)` returns a `Float64` (not a length-1 vector) when
`variable_dimension(ocp) == 1`, per the ["1-D is a
scalar"](https://github.com/control-toolbox/Handbook/blob/main/philosophy/dimension-and-shape.md)
convention. This scalar was written raw into JLD2/JSON exports (`_discretize_all_components`
stored `variable(sol)` unchanged), and `import_ocp_solution` then failed on re-import with:

```
MethodError: no method matching Vector{Float64}(::Float64)
```

because the reconstruction path expects `data["variable"]` to be vector-like.

Confirmed reproducible directly in CTModels.jl (no dependency on OptimalControl.jl):
`variable_dimension == 0` and `>= 2` round-trip fine (already vectors), only `== 1`
breaks — matching the issue report exactly.

## Fix

- `Solutions._serialize_solution` now normalizes `"variable"` to a `Vector{Float64}` on
  the wire via a new `Solutions._as_vector` helper, instead of writing the raw
  scalar/vector.
- `Serialization._extract_time_vector` (used by the JLD2 path and the unified
  reconstruction helper) and the JSON extension's `"variable"` field both accept the
  scalar format too — so JLD2/JSON files exported by an older CTModels version for a
  1-D-variable problem become importable without needing to re-export them.

## Breaking change

None. `variable(sol)` was already a scalar for a 1-D variable; only the on-disk format
and the importer's robustness changed. See `BREAKING.md`.

## Test plan

- [x] New regression tests in `test/suite/serialization/test_serialization_units.jl`:
      wire-format assertion (`data["variable"] isa Vector{Float64}`), JLD2 round-trip,
      JSON round-trip, and backward-compat test simulating a pre-fix export (bare
      scalar already on disk).
- [x] Full test suite green: 70,676/70,676 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)