### PR TITLE
Add palette-aware displays for CTModels types

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -129,7 +129,7 @@ end
 bases_file = joinpath(@__DIR__, "build", "bases.txt")
 if isfile(bases_file)
     DocumenterVitepress.deploydocs(;
-        repo=repo_url * ".git", devbranch="main", push_preview=true
+        repo=repo_url * ".git", devbranch="main", push_preview=false
     )
 else
     @info "Skipping deployment: no bases were built (prerelease with existing higher stable release)."

--- a/docs/src/model/display.md
+++ b/docs/src/model/display.md
@@ -103,6 +103,93 @@ macro-based DSL (e.g. OptimalControl.jl) that stores the original user code.
 When no definition is set ([`EmptyDefinition`](@ref CTModels.Components.EmptyDefinition)),
 this section is skipped silently.
 
+## Displaying component types
+
+The same display conventions are used by the concrete component types that make up a
+model. The types are normally inspected through their public accessors, while `show`
+provides a compact visual summary of their structure:
+
+```@repl display
+state_model = CTModels.Components.StateModel("x", ["x₁", "x₂"])
+CTModels.Components.name(state_model)
+CTModels.Components.components(state_model)
+CTModels.Components.dimension(state_model)
+```
+
+```@example display
+state_model
+```
+
+A solution component indicates that its value is a callable trajectory without expanding
+the closure. The value and metadata remain available through accessors:
+
+```@repl display
+state_solution = CTModels.Components.StateModelSolution("x", ["x₁"], t -> 2t)
+CTModels.Components.value(state_solution)(0.5)
+CTModels.Components.name(state_solution)
+CTModels.Components.dimension(state_solution)
+```
+
+```@example display
+state_solution
+```
+
+Time models, objectives, and constraints follow the same pattern. Their summaries expose
+semantic fields while the accessors provide the programmatic interface:
+
+```@repl display
+times_model = CTModels.Components.TimesModel(
+    CTModels.Components.FixedTimeModel(0.0, "t₀"),
+    CTModels.Components.FreeTimeModel(2, "tf"),
+    "t",
+)
+CTModels.Components.initial(times_model)
+CTModels.Components.final(times_model)
+CTModels.Components.initial_time_name(times_model)
+CTModels.Components.final_time_name(times_model)
+```
+
+```@example display
+times_model
+```
+
+```@repl display
+objective_model = CTModels.Components.MayerObjectiveModel((x0, xf, v) -> xf[1], :min)
+CTModels.Components.criterion(objective_model)
+CTModels.Components.mayer(objective_model)
+```
+
+```@example display
+objective_model
+```
+
+For solution support objects, the display summarizes grid sizes, optional solver metadata,
+and dual presence rather than printing all numerical data:
+
+```@repl display
+grid = CTModels.UnifiedTimeGridModel(collect(range(0.0, 1.0; length=5)))
+infos = CTModels.SolverInfos(12, :first_order, "converged", true, 1e-8, Dict{Symbol,Any}())
+grid
+infos
+```
+
+The corresponding accessors can be used without relying on the stored fields:
+
+```@example display
+CTModels.time_grid_model(
+    CTModels.build_solution(
+        ocp,
+        collect(range(0.0, 1.0; length=3)),
+        zeros(3, 2),
+        zeros(3, 1),
+        Float64[],
+        zeros(3, 2);
+        objective=0.0,
+        successful=true,
+    ),
+)
+```
+
 ## Plotting solutions
 
 The `Display` module registers a `RecipesBase.plot` method for

--- a/src/Building/constraint_composers.jl
+++ b/src/Building/constraint_composers.jl
@@ -103,7 +103,8 @@ $(TYPEDSIGNATURES)
 Compact string representation of [`CTModels.Building.CompositeConstraint`](@extref).
 """
 function Base.show(io::IO, f::CompositeConstraint{Sig,CS}) where {Sig,CS}
-    return print(io, "CompositeConstraint{:", Sig, "}(n=", f.n, ", dims=", f.dims, ")")
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "CompositeConstraint", fmt.reset, "{", fmt.keyword, ":", Sig, fmt.reset, "}(n=", fmt.count, f.n, fmt.reset, ", dims=", fmt.value, f.dims, fmt.reset, ")")
 end
 
 """
@@ -114,8 +115,9 @@ Detailed string representation of [`CTModels.Building.CompositeConstraint`](@ext
 function Base.show(
     io::IO, ::MIME"text/plain", f::CompositeConstraint{Sig,CS}
 ) where {Sig,CS}
-    print(io, "CompositeConstraint")
-    print(io, "\n  sig:  :", Sig)
-    print(io, "\n  n:    ", f.n)
-    return print(io, "\n  dims: ", f.dims)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "CompositeConstraint", fmt.reset)
+    print(io, "\n  ", fmt.label, "sig:  ", fmt.reset, fmt.keyword, ":", Sig, fmt.reset)
+    print(io, "\n  ", fmt.label, "n:    ", fmt.reset, fmt.count, f.n, fmt.reset)
+    return print(io, "\n  ", fmt.label, "dims: ", fmt.reset, fmt.value, f.dims, fmt.reset)
 end

--- a/src/Components/functors.jl
+++ b/src/Components/functors.jl
@@ -30,13 +30,15 @@ end
 (f::ConstantInTime)(::Real) = f.value
 
 function Base.show(io::IO, f::ConstantInTime)
-    return print(io, "ConstantInTime(", f.value, ")")
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "ConstantInTime", fmt.reset, "(", fmt.value, f.value, fmt.reset, ")")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", f::ConstantInTime{V}) where {V}
-    print(io, "ConstantInTime")
-    print(io, "\n  value: ", f.value)
-    return print(io, "\n  type:  ", V)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "ConstantInTime", fmt.reset)
+    print(io, "\n  ", fmt.label, "value: ", fmt.reset, fmt.value, f.value, fmt.reset)
+    return print(io, "\n  ", fmt.label, "type:  ", fmt.reset, fmt.type, V, fmt.reset)
 end
 
 # ------------------------------------------------------------------------------
@@ -75,11 +77,13 @@ end
 (f::CoercedTrajectory)(t) = f.coerce(f.inner(t))
 
 function Base.show(io::IO, f::CoercedTrajectory)
-    return print(io, "CoercedTrajectory(", nameof(f.coerce), ")")
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "CoercedTrajectory", fmt.reset, "(", fmt.keyword, nameof(f.coerce), fmt.reset, ")")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", f::CoercedTrajectory{F,C}) where {F,C}
-    print(io, "CoercedTrajectory")
-    print(io, "\n  inner:  ", nameof(typeof(f.inner)))
-    return print(io, "\n  coerce: ", nameof(f.coerce))
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "CoercedTrajectory", fmt.reset)
+    print(io, "\n  ", fmt.label, "inner:  ", fmt.reset, fmt.type, nameof(typeof(f.inner)), fmt.reset)
+    return print(io, "\n  ", fmt.label, "coerce: ", fmt.reset, fmt.keyword, nameof(f.coerce), fmt.reset)
 end

--- a/src/Display/Display.jl
+++ b/src/Display/Display.jl
@@ -9,6 +9,9 @@ problems and solutions in human-readable formats.
 # Organisation
 
 - **ansi.jl**: Generic Expr printing ([`CTModels.Display.__print`](@extref))
+- **helpers.jl**: Shared palette-aware field and tree rendering helpers
+- **components.jl**: Display for concrete component model types
+- **solution_types.jl**: Display for solution support types
 - **definition.jl**: Abstract (symbolic) definition printing ([`CTModels.Display._print_abstract_definition`](@extref))
 - **mathematical.jl**: Mathematical definition printing ([`CTModels.Display.__print_mathematical_definition`](@extref))
 - **model.jl**: Display for [`CTModels.Models.Model`](@extref)
@@ -38,7 +41,7 @@ module Display
 
 using DocStringExtensions: TYPEDSIGNATURES
 
-using CTBase: CTBase, Exceptions, Core
+using CTBase: CTBase, Exceptions
 using MLStyle: MLStyle
 using RecipesBase: RecipesBase
 using MacroTools: MacroTools
@@ -50,6 +53,9 @@ using ..Solutions
 
 # Include display functions (split by responsibility)
 include(joinpath(@__DIR__, "ansi.jl"))
+include(joinpath(@__DIR__, "helpers.jl"))
+include(joinpath(@__DIR__, "components.jl"))
+include(joinpath(@__DIR__, "solution_types.jl"))
 include(joinpath(@__DIR__, "definition.jl"))
 include(joinpath(@__DIR__, "mathematical.jl"))
 include(joinpath(@__DIR__, "model.jl"))

--- a/src/Display/components.jl
+++ b/src/Display/components.jl
@@ -1,0 +1,223 @@
+# ------------------------------------------------------------------------------
+# Display for component model types
+# ------------------------------------------------------------------------------
+
+"""Return the concrete display name for a component model."""
+_component_name(model) = nameof(typeof(model))
+
+"""Collect accessor-backed fields for a state, control, or variable model."""
+function _space_fields(model::Union{Components.StateModel,Components.ControlModel,Components.VariableModel})
+    return [
+        ("name", Components.name(model), fmt -> fmt.value),
+        ("dimension", Components.dimension(model), fmt -> fmt.count),
+        ("components", join(Components.components(model), ", "), fmt -> fmt.value),
+    ]
+end
+
+"""Collect display fields for a component model carrying a trajectory or value."""
+function _solution_space_fields(model)
+    return [
+        ("name", Components.name(model), fmt -> fmt.value),
+        ("dimension", Components.dimension(model), fmt -> fmt.count),
+        ("components", join(Components.components(model), ", "), fmt -> fmt.value),
+        ("value", "<callable>", fmt -> fmt.muted),
+    ]
+end
+
+"""Render a state, control, or variable model in compact or detailed form."""
+function _show_space(io::IO, model; detailed::Bool=false)
+    fmt = format_codes(io)
+    fields = _space_fields(model)
+    if detailed
+        return _show_detail(io, string(nameof(typeof(model))); fmt=fmt, fields=_styled_fields(fields, fmt))
+    end
+    return _show_compact(io, string(nameof(typeof(model))); fmt=fmt, fields=_compact_fields(fields))
+end
+
+"""Apply the selected palette role to each display field."""
+function _styled_fields(fields, fmt)
+    return [(field[1], field[2], field[3](fmt)) for field in fields]
+end
+
+"""Remove palette callbacks from fields used by compact displays."""
+_compact_fields(fields) = [(field[1], field[2]) for field in fields]
+
+for T in (:StateModel, :ControlModel, :VariableModel)
+    @eval begin
+        function Base.show(io::IO, model::Components.$T)
+            return _show_space(io, model)
+        end
+        function Base.show(io::IO, ::MIME"text/plain", model::Components.$T)
+            return _show_space(io, model; detailed=true)
+        end
+    end
+end
+
+"""Render a solution state, control, or variable component."""
+function _show_solution_space(io::IO, model; detailed::Bool=false)
+    fmt = format_codes(io)
+    fields = _solution_space_fields(model)
+    model isa Components.ControlModelSolution && push!(
+        fields, ("interpolation", Components.interpolation(model), fmt -> fmt.keyword)
+    )
+    return detailed ?
+        _show_detail(io, nameof(typeof(model)); fmt=fmt, fields=_styled_fields(fields, fmt)) :
+        _show_compact(io, nameof(typeof(model)); fmt=fmt, fields=_compact_fields(fields))
+end
+
+for T in (:StateModelSolution, :ControlModelSolution, :VariableModelSolution)
+    @eval begin
+        Base.show(io::IO, model::Components.$T) = _show_solution_space(io, model)
+        Base.show(io::IO, ::MIME"text/plain", model::Components.$T) =
+            _show_solution_space(io, model; detailed=true)
+    end
+end
+
+for T in (:EmptyControlModel, :EmptyVariableModel)
+    @eval begin
+        function Base.show(io::IO, ::Components.$T)
+            fmt = format_codes(io)
+            return print(io, fmt.name, string(nameof(Components.$T)), fmt.reset, "()")
+        end
+        function Base.show(io::IO, ::MIME"text/plain", ::Components.$T)
+            fmt = format_codes(io)
+            print_header(io, string(nameof(Components.$T)); fmt=fmt)
+            return print_field(io, "status", :empty; last=true, fmt=fmt, value_style=fmt.muted)
+        end
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a fixed time model compactly using its name and time value.
+"""
+function Base.show(io::IO, model::Components.FixedTimeModel)
+    fmt = format_codes(io)
+    return _show_compact(io, "FixedTimeModel"; fmt=fmt, fields=[("name", Components.name(model)), ("time", Base.time(model))])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a fixed time model as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", model::Components.FixedTimeModel)
+    fmt = format_codes(io)
+    return _show_detail(io, "FixedTimeModel"; fmt=fmt, fields=[("name", Components.name(model), fmt.value), ("time", Base.time(model), fmt.value)])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a free time model compactly using its name and variable index.
+"""
+function Base.show(io::IO, model::Components.FreeTimeModel)
+    fmt = format_codes(io)
+    return _show_compact(io, "FreeTimeModel"; fmt=fmt, fields=[("name", Components.name(model)), ("index", Components.index(model))])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a free time model as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", model::Components.FreeTimeModel)
+    fmt = format_codes(io)
+    return _show_detail(io, "FreeTimeModel"; fmt=fmt, fields=[("name", Components.name(model), fmt.value), ("index", Components.index(model), fmt.count)])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display the initial and final time models compactly.
+"""
+function Base.show(io::IO, model::Components.TimesModel)
+    fmt = format_codes(io)
+    return _show_compact(io, "TimesModel"; fmt=fmt, fields=[("initial", Components.initial(model)), ("final", Components.final(model)), ("time_name", Components.time_name(model))])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display the initial and final time models as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", model::Components.TimesModel)
+    fmt = format_codes(io)
+    return _show_detail(io, "TimesModel"; fmt=fmt, fields=[("initial", Components.initial(model), ""), ("final", Components.final(model), ""), ("time_name", Components.time_name(model), fmt.value)])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Render an objective model without expanding its callable fields.
+"""
+function _show_objective(io::IO, model, fields; detailed::Bool=false)
+    fmt = format_codes(io)
+    values = Any[("criterion", Components.criterion(model), fmt -> fmt.keyword)]
+    Components.has_mayer_cost(model) && push!(values, ("mayer", "<callable>", fmt -> fmt.muted))
+    Components.has_lagrange_cost(model) && push!(values, ("lagrange", "<callable>", fmt -> fmt.muted))
+    return detailed ? _show_detail(io, nameof(typeof(model)); fmt=fmt, fields=_styled_fields(values, fmt)) : _show_compact(io, nameof(typeof(model)); fmt=fmt, fields=_compact_fields(values))
+end
+
+for T in (:MayerObjectiveModel, :LagrangeObjectiveModel, :BolzaObjectiveModel)
+    @eval begin
+        Base.show(io::IO, model::Components.$T) = _show_objective(io, model, nothing)
+        Base.show(io::IO, ::MIME"text/plain", model::Components.$T) = _show_objective(io, model, nothing; detailed=true)
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a compact summary of the five constraint families.
+"""
+function Base.show(io::IO, model::Components.ConstraintsModel)
+    fmt = format_codes(io)
+    fields = [
+        ("path nonlinear", length(Components.path_constraints_nl(model))),
+        ("boundary nonlinear", length(Components.boundary_constraints_nl(model))),
+        ("state box", length(Components.state_constraints_box(model))),
+        ("control box", length(Components.control_constraints_box(model))),
+        ("variable box", length(Components.variable_constraints_box(model))),
+    ]
+    return _show_compact(io, "ConstraintsModel"; fmt=fmt, fields=fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a detailed tree summary of the five constraint families.
+"""
+function Base.show(io::IO, ::MIME"text/plain", model::Components.ConstraintsModel)
+    fmt = format_codes(io)
+    fields = [
+        ("path nonlinear", length(Components.path_constraints_nl(model)), fmt.count),
+        ("boundary nonlinear", length(Components.boundary_constraints_nl(model)), fmt.count),
+        ("state box", length(Components.state_constraints_box(model)), fmt.count),
+        ("control box", length(Components.control_constraints_box(model)), fmt.count),
+        ("variable box", length(Components.variable_constraints_box(model)), fmt.count),
+    ]
+    return _show_detail(io, "ConstraintsModel"; fmt=fmt, fields=fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display the empty symbolic definition explicitly.
+"""
+function Base.show(io::IO, ::Components.EmptyDefinition)
+    fmt = format_codes(io)
+    return print(io, fmt.name, "EmptyDefinition", fmt.reset, "()")
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display the empty symbolic definition as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", ::Components.EmptyDefinition)
+    fmt = format_codes(io)
+    print_header(io, "EmptyDefinition"; fmt=fmt)
+    return print_field(io, "status", :empty; last=true, fmt=fmt, value_style=fmt.muted)
+end

--- a/src/Display/helpers.jl
+++ b/src/Display/helpers.jl
@@ -1,0 +1,97 @@
+# ------------------------------------------------------------------------------
+# Shared palette-aware display helpers
+# ------------------------------------------------------------------------------
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the active CTBase palette codes for `io`.
+"""
+format_codes(io::IO) = CTBase.Core.get_format_codes(io)
+
+"""
+$(TYPEDSIGNATURES)
+
+Print a palette-styled type header without a trailing newline.
+"""
+function print_header(io::IO, name; fmt=format_codes(io))
+    print(io, fmt.name, name, fmt.reset)
+    return nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Render a nested display value while preserving the colour context of `io`.
+"""
+function _display_value(io::IO, value)
+    return value isa AbstractString ? value : sprint(
+        print, value; context=IOContext(io, :color => get(io, :color, false))
+    )
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Print one labelled tree field using semantic palette roles.
+"""
+function print_field(
+    io::IO, label, value; last::Bool=false, fmt=format_codes(io), value_style=nothing
+)
+    style = value_style === nothing ? fmt.value : value_style
+    reset = isempty(style) ? "" : fmt.reset
+    branch = last ? "└─ " : "├─ "
+    value_string = _display_value(io, value)
+    lines = split(value_string, '\n')
+
+    print(io, '\n', fmt.muted, branch, fmt.reset)
+    isempty(string(label)) || print(io, fmt.label, label, fmt.reset, ": ")
+    print(io, style, first(lines), reset)
+    if length(lines) > 1
+        continuation = last ? "   " : string(fmt.muted, "│", fmt.reset, "  ")
+        for line in @view lines[2:end]
+            print(io, '\n', continuation, style, line, reset)
+        end
+    end
+    return nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Print a sequence of labelled fields and mark the final field with `└─`.
+"""
+function print_fields(io::IO, fields; fmt=format_codes(io))
+    for (index, field) in enumerate(fields)
+        style = length(field) >= 3 ? field[3] : nothing
+        print_field(io, field[1], field[2]; last=index == length(fields), fmt=fmt, value_style=style)
+    end
+    return nothing
+end
+
+_callable_name(f) = nameof(typeof(f))
+_callable_value(_) = "<callable>"
+
+"""
+$(TYPEDSIGNATURES)
+
+Print a compact one-line representation with palette-styled fields.
+"""
+function _show_compact(io::IO, type_name; fields=(), fmt=format_codes(io))
+    print(io, fmt.name, type_name, fmt.reset, "(")
+    for (index, field) in enumerate(fields)
+        index > 1 && print(io, ", ")
+        print(io, fmt.label, field[1], fmt.reset, "=", fmt.value, field[2], fmt.reset)
+    end
+    return print(io, ")")
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Print a detailed tree representation with palette-styled fields.
+"""
+function _show_detail(io::IO, type_name; fields=(), fmt=format_codes(io))
+    print_header(io, type_name; fmt=fmt)
+    return print_fields(io, fields; fmt=fmt)
+end

--- a/src/Display/solution_types.jl
+++ b/src/Display/solution_types.jl
@@ -1,0 +1,151 @@
+# ------------------------------------------------------------------------------
+# Display for solution support types
+# ------------------------------------------------------------------------------
+
+"""Summarize a time grid by its size and endpoint values."""
+function _grid_summary(grid)
+    isempty(grid) && return "0 points"
+    return string(length(grid), " points [", first(grid), ", ", last(grid), "]")
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a unified time grid compactly with its size and endpoints.
+"""
+function Base.show(io::IO, grid::Solutions.UnifiedTimeGridModel)
+    fmt = format_codes(io)
+    return _show_compact(io, "UnifiedTimeGridModel"; fmt=fmt, fields=[("points", length(grid.value)), ("first", first(grid.value)), ("last", last(grid.value))])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display a unified time grid as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", grid::Solutions.UnifiedTimeGridModel)
+    fmt = format_codes(io)
+    fields = isempty(grid.value) ? [("points", 0, fmt.count)] : [
+        ("points", length(grid.value), fmt.count),
+        ("first", first(grid.value), fmt.value),
+        ("last", last(grid.value), fmt.value),
+    ]
+    return _show_detail(io, "UnifiedTimeGridModel"; fmt=fmt, fields=fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display the component sizes of a multiple time grid compactly.
+"""
+function Base.show(io::IO, grid::Solutions.MultipleTimeGridModel)
+    fmt = format_codes(io)
+    fields = [(string(name), _grid_summary(getfield(grid.grids, name))) for name in keys(grid.grids)]
+    return _show_compact(io, "MultipleTimeGridModel"; fmt=fmt, fields=fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display each component grid as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", grid::Solutions.MultipleTimeGridModel)
+    fmt = format_codes(io)
+    fields = [(string(name), _grid_summary(getfield(grid.grids, name)), fmt.value) for name in keys(grid.grids)]
+    return _show_detail(io, "MultipleTimeGridModel"; fmt=fmt, fields=fields)
+end
+
+function Base.show(io::IO, ::Solutions.EmptyTimeGridModel)
+    fmt = format_codes(io)
+    return print(io, fmt.name, "EmptyTimeGridModel", fmt.reset, "()")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ::Solutions.EmptyTimeGridModel)
+    fmt = format_codes(io)
+    print_header(io, "EmptyTimeGridModel"; fmt=fmt)
+    return print_field(io, "status", :empty; last=true, fmt=fmt, value_style=fmt.muted)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display solver information compactly.
+"""
+function Base.show(io::IO, infos::Solutions.SolverInfos)
+    fmt = format_codes(io)
+    fields = [
+        ("status", infos.status),
+        ("successful", infos.successful),
+        ("iterations", infos.iterations),
+        ("constraints_violation", infos.constraints_violation),
+    ]
+    return _show_compact(io, "SolverInfos"; fmt=fmt, fields=fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display provided solver information as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", infos::Solutions.SolverInfos)
+    fmt = format_codes(io)
+    candidates = [
+        ("status", infos.status, fmt.keyword),
+        ("successful", infos.successful, infos.successful ? fmt.success : fmt.error),
+        ("iterations", infos.iterations, fmt.count),
+        ("message", infos.message, fmt.value),
+        ("constraints violation", infos.constraints_violation, fmt.value),
+    ]
+    fields = [field for field in candidates if !(field[2] isa CTBase.Core.NotProvidedType)]
+    return _show_detail(io, "SolverInfos"; fmt=fmt, fields=fields)
+end
+
+"""Return whether an optional dual value is present."""
+function _dual_presence(value)
+    return value === nothing ? :none : :present
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display which dual constraint families are present.
+"""
+function Base.show(io::IO, dual::Solutions.DualModel)
+    fmt = format_codes(io)
+    fields = [
+        ("path", _dual_presence(dual.path_constraints_dual)),
+        ("boundary", _dual_presence(dual.boundary_constraints_dual)),
+        ("state box", _dual_presence(dual.state_constraints_lb_dual) !== :none || _dual_presence(dual.state_constraints_ub_dual) !== :none ? :present : :none),
+        ("control box", _dual_presence(dual.control_constraints_lb_dual) !== :none || _dual_presence(dual.control_constraints_ub_dual) !== :none ? :present : :none),
+        ("variable box", _dual_presence(dual.variable_constraints_lb_dual) !== :none || _dual_presence(dual.variable_constraints_ub_dual) !== :none ? :present : :none),
+    ]
+    return _show_compact(io, "DualModel"; fmt=fmt, fields=fields)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Display dual presence as a labelled tree.
+"""
+function Base.show(io::IO, ::MIME"text/plain", dual::Solutions.DualModel)
+    fmt = format_codes(io)
+    fields = [
+        ("path", _dual_presence(dual.path_constraints_dual), fmt.keyword),
+        ("boundary", _dual_presence(dual.boundary_constraints_dual), fmt.keyword),
+        ("state box", _dual_presence(dual.state_constraints_lb_dual) !== :none || _dual_presence(dual.state_constraints_ub_dual) !== :none ? :present : :none, fmt.keyword),
+        ("control box", _dual_presence(dual.control_constraints_lb_dual) !== :none || _dual_presence(dual.control_constraints_ub_dual) !== :none ? :present : :none, fmt.keyword),
+        ("variable box", _dual_presence(dual.variable_constraints_lb_dual) !== :none || _dual_presence(dual.variable_constraints_ub_dual) !== :none ? :present : :none, fmt.keyword),
+    ]
+    return _show_detail(io, "DualModel"; fmt=fmt, fields=fields)
+end
+
+function Base.show(io::IO, ::Solutions.EmptyDualModel)
+    fmt = format_codes(io)
+    return print(io, fmt.name, "EmptyDualModel", fmt.reset, "()")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ::Solutions.EmptyDualModel)
+    fmt = format_codes(io)
+    print_header(io, "EmptyDualModel"; fmt=fmt)
+    return print_field(io, "status", :empty; last=true, fmt=fmt, value_style=fmt.muted)
+end

--- a/src/Init/init_functors.jl
+++ b/src/Init/init_functors.jl
@@ -188,14 +188,25 @@ $(TYPEDSIGNATURES)
 Compact string representation of [`CTModels.Init.MergedTrajectory`](@extref).
 """
 function Base.show(io::IO, f::MergedTrajectory{F,C}) where {F,C}
+    fmt = CTBase.Core.get_format_codes(io)
     return print(
         io,
-        "MergedTrajectory(dim=",
+        fmt.name,
+        "MergedTrajectory",
+        fmt.reset,
+        "(dim=",
+        fmt.count,
         f.dim,
-        ", role=:",
+        fmt.reset,
+        ", role=",
+        fmt.keyword,
+        ":",
         f.role,
+        fmt.reset,
         ", ncomps=",
+        fmt.count,
         length(f.comps),
+        fmt.reset,
         ")",
     )
 end
@@ -206,8 +217,9 @@ $(TYPEDSIGNATURES)
 Detailed string representation of [`CTModels.Init.MergedTrajectory`](@extref).
 """
 function Base.show(io::IO, ::MIME"text/plain", f::MergedTrajectory{F,C}) where {F,C}
-    print(io, "MergedTrajectory")
-    print(io, "\n  role:   :", f.role)
-    print(io, "\n  dim:    ", f.dim)
-    return print(io, "\n  ncomps: ", length(f.comps))
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "MergedTrajectory", fmt.reset)
+    print(io, "\n  ", fmt.label, "role:   ", fmt.reset, fmt.keyword, ":", f.role, fmt.reset)
+    print(io, "\n  ", fmt.label, "dim:    ", fmt.reset, fmt.count, f.dim, fmt.reset)
+    return print(io, "\n  ", fmt.label, "ncomps: ", fmt.reset, fmt.count, length(f.comps), fmt.reset)
 end

--- a/src/Init/show.jl
+++ b/src/Init/show.jl
@@ -17,7 +17,7 @@ functions; `variable` shows its value or `(none)` when empty.
 See also: [`CTModels.Init.InitialGuess`](@extref), [`CTModels.Init.PreInitialGuess`](@extref)
 """
 function Base.show(io::IO, ::MIME"text/plain", init::InitialGuess)
-    fmt = Core.get_format_codes(io)
+    fmt = CTBase.Core.get_format_codes(io)
     println(io, fmt.name, "InitialGuess", fmt.reset)
     println(io, "  ", fmt.label, "state:   ", fmt.reset, fmt.muted, "<callable>", fmt.reset)
     println(io, "  ", fmt.label, "control: ", fmt.reset, fmt.muted, "<callable>", fmt.reset)
@@ -49,7 +49,7 @@ Print a compact one-line representation of the initial guess to `io`.
 See also: [`CTModels.Init.InitialGuess`](@extref)
 """
 function Base.show(io::IO, init::InitialGuess)
-    fmt = Core.get_format_codes(io)
+    fmt = CTBase.Core.get_format_codes(io)
     v_str = isempty(init.variable) ? "(none)" : string(init.variable)
     return print(
         io,
@@ -76,7 +76,7 @@ Displays the type name, then the `typeof` of each raw field (`state`, `control`,
 See also: [`CTModels.Init.PreInitialGuess`](@extref), [`CTModels.Init.InitialGuess`](@extref)
 """
 function Base.show(io::IO, ::MIME"text/plain", pre::PreInitialGuess)
-    fmt = Core.get_format_codes(io)
+    fmt = CTBase.Core.get_format_codes(io)
     println(io, fmt.name, "PreInitialGuess", fmt.reset)
     println(
         io, "  ", fmt.label, "state:   ", fmt.reset, fmt.type, typeof(pre.state), fmt.reset
@@ -115,7 +115,7 @@ Print a compact one-line representation of the pre-initial guess to `io`.
 See also: [`CTModels.Init.PreInitialGuess`](@extref)
 """
 function Base.show(io::IO, pre::PreInitialGuess)
-    fmt = Core.get_format_codes(io)
+    fmt = CTBase.Core.get_format_codes(io)
     return print(
         io,
         fmt.name,

--- a/src/Models/constraint_functors.jl
+++ b/src/Models/constraint_functors.jl
@@ -34,7 +34,8 @@ $(TYPEDSIGNATURES)
 Print a compact one-line representation of a [`SubPathConstraint`](@extref).
 """
 function Base.show(io::IO, f::SubPathConstraint)
-    return print(io, "SubPathConstraint(n=", f.n, ", indices=", f.indices, ")")
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "SubPathConstraint", fmt.reset, "(n=", fmt.count, f.n, fmt.reset, ", indices=", fmt.value, f.indices, fmt.reset, ")")
 end
 
 """
@@ -43,9 +44,10 @@ $(TYPEDSIGNATURES)
 Print a multi-line representation of a [`SubPathConstraint`](@extref).
 """
 function Base.show(io::IO, ::MIME"text/plain", f::SubPathConstraint{CP,I}) where {CP,I}
-    print(io, "SubPathConstraint")
-    print(io, "\n  n:       ", f.n)
-    return print(io, "\n  indices: ", f.indices)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "SubPathConstraint", fmt.reset)
+    print(io, "\n  ", fmt.label, "n:       ", fmt.reset, fmt.count, f.n, fmt.reset)
+    return print(io, "\n  ", fmt.label, "indices: ", fmt.reset, fmt.value, f.indices, fmt.reset)
 end
 
 # ------------------------------------------------------------------------------
@@ -82,7 +84,8 @@ $(TYPEDSIGNATURES)
 Print a compact one-line representation of a [`SubBoundaryConstraint`](@extref).
 """
 function Base.show(io::IO, f::SubBoundaryConstraint)
-    return print(io, "SubBoundaryConstraint(n=", f.n, ", indices=", f.indices, ")")
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "SubBoundaryConstraint", fmt.reset, "(n=", fmt.count, f.n, fmt.reset, ", indices=", fmt.value, f.indices, fmt.reset, ")")
 end
 
 """
@@ -91,9 +94,10 @@ $(TYPEDSIGNATURES)
 Print a multi-line representation of a [`SubBoundaryConstraint`](@extref).
 """
 function Base.show(io::IO, ::MIME"text/plain", f::SubBoundaryConstraint{CP,I}) where {CP,I}
-    print(io, "SubBoundaryConstraint")
-    print(io, "\n  n:       ", f.n)
-    return print(io, "\n  indices: ", f.indices)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "SubBoundaryConstraint", fmt.reset)
+    print(io, "\n  ", fmt.label, "n:       ", fmt.reset, fmt.count, f.n, fmt.reset)
+    return print(io, "\n  ", fmt.label, "indices: ", fmt.reset, fmt.value, f.indices, fmt.reset)
 end
 
 # ------------------------------------------------------------------------------
@@ -129,7 +133,8 @@ $(TYPEDSIGNATURES)
 Print a compact one-line representation of a [`BoxProjection`](@extref).
 """
 function Base.show(io::IO, f::BoxProjection{Slot,CIDX}) where {Slot,CIDX}
-    return print(io, "BoxProjection{:", Slot, "}(", f.cidx, ")")
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "BoxProjection", fmt.reset, "{", fmt.keyword, ":", Slot, fmt.reset, "}(", fmt.value, f.cidx, fmt.reset, ")")
 end
 
 """
@@ -140,7 +145,8 @@ Print a multi-line representation of a [`BoxProjection`](@extref).
 function Base.show(
     io::IO, ::MIME"text/plain", f::BoxProjection{Slot,CIDX}
 ) where {Slot,CIDX}
-    print(io, "BoxProjection")
-    print(io, "\n  slot: :", Slot)
-    return print(io, "\n  cidx: ", f.cidx)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "BoxProjection", fmt.reset)
+    print(io, "\n  ", fmt.label, "slot: ", fmt.reset, fmt.keyword, ":", Slot, fmt.reset)
+    return print(io, "\n  ", fmt.label, "cidx: ", fmt.reset, fmt.value, f.cidx, fmt.reset)
 end

--- a/src/Serialization/types.jl
+++ b/src/Serialization/types.jl
@@ -32,3 +32,25 @@ No fields (empty struct used as a type tag).
 See also: [`CTModels.Serialization.AbstractTag`](@extref), [`CTModels.Serialization.JLD2Tag`](@extref).
 """
 struct JSON3Tag <: AbstractTag end
+
+function Base.show(io::IO, ::JLD2Tag)
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "JLD2Tag", fmt.reset, "()")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ::JLD2Tag)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "JLD2Tag", fmt.reset)
+    return print(io, "\n  ", fmt.label, "kind: ", fmt.reset, fmt.keyword, ":format_tag", fmt.reset)
+end
+
+function Base.show(io::IO, ::JSON3Tag)
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "JSON3Tag", fmt.reset, "()")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ::JSON3Tag)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "JSON3Tag", fmt.reset)
+    return print(io, "\n  ", fmt.label, "kind: ", fmt.reset, fmt.keyword, ":format_tag", fmt.reset)
+end

--- a/src/Solutions/dual_functors.jl
+++ b/src/Solutions/dual_functors.jl
@@ -23,13 +23,15 @@ end
 (f::DualSlice)(t) = f.duals(t)[f.idx]
 
 function Base.show(io::IO, f::DualSlice)
-    return print(io, "DualSlice(", nameof(typeof(f.duals)), ", ", f.idx, ")")
+    fmt = CTBase.Core.get_format_codes(io)
+    return print(io, fmt.name, "DualSlice", fmt.reset, "(", fmt.type, nameof(typeof(f.duals)), fmt.reset, ", ", fmt.value, f.idx, fmt.reset, ")")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", f::DualSlice{D,I}) where {D,I}
-    print(io, "DualSlice")
-    print(io, "\n  duals: ", nameof(typeof(f.duals)))
-    return print(io, "\n  idx:   ", f.idx)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "DualSlice", fmt.reset)
+    print(io, "\n  ", fmt.label, "duals: ", fmt.reset, fmt.type, nameof(typeof(f.duals)), fmt.reset)
+    return print(io, "\n  ", fmt.label, "idx:   ", fmt.reset, fmt.value, f.idx, fmt.reset)
 end
 
 # ------------------------------------------------------------------------------
@@ -55,21 +57,20 @@ end
 (f::BoxDualDiff)(t) = f.lb(t)[f.idx] - f.ub(t)[f.idx]
 
 function Base.show(io::IO, f::BoxDualDiff)
+    fmt = CTBase.Core.get_format_codes(io)
     return print(
         io,
-        "BoxDualDiff(",
-        nameof(typeof(f.lb)),
-        ", ",
-        nameof(typeof(f.ub)),
-        ", ",
-        f.idx,
-        ")",
+        fmt.name, "BoxDualDiff", fmt.reset, "(",
+        fmt.type, nameof(typeof(f.lb)), fmt.reset, ", ",
+        fmt.type, nameof(typeof(f.ub)), fmt.reset, ", ",
+        fmt.value, f.idx, fmt.reset, ")",
     )
 end
 
 function Base.show(io::IO, ::MIME"text/plain", f::BoxDualDiff{DL,DU,I}) where {DL,DU,I}
-    print(io, "BoxDualDiff")
-    print(io, "\n  lb:  ", nameof(typeof(f.lb)))
-    print(io, "\n  ub:  ", nameof(typeof(f.ub)))
-    return print(io, "\n  idx: ", f.idx)
+    fmt = CTBase.Core.get_format_codes(io)
+    print(io, fmt.name, "BoxDualDiff", fmt.reset)
+    print(io, "\n  ", fmt.label, "lb:  ", fmt.reset, fmt.type, nameof(typeof(f.lb)), fmt.reset)
+    print(io, "\n  ", fmt.label, "ub:  ", fmt.reset, fmt.type, nameof(typeof(f.ub)), fmt.reset)
+    return print(io, "\n  ", fmt.label, "idx: ", fmt.reset, fmt.value, f.idx, fmt.reset)
 end

--- a/src/Solutions/show.jl
+++ b/src/Solutions/show.jl
@@ -24,7 +24,7 @@ The display is a single tree rooted at "Solution":
 See also: [`CTModels.Solutions.Solution`](@extref)
 """
 function Base.show(io::IO, ::MIME"text/plain", sol::Solution)
-    fmt = Core.get_format_codes(io)
+    fmt = CTBase.Core.get_format_codes(io)
 
     # ── Header ──────────────────────────────────────────────────────────────
     ok = Solutions.successful(sol)
@@ -33,7 +33,7 @@ function Base.show(io::IO, ::MIME"text/plain", sol::Solution)
     println(io, fmt.name, "Solution", fmt.reset, "  ", ok_code, ok_sym, fmt.reset)
 
     # ── Optional solver-metadata — only display when provided ────────────────
-    _np = Core.NotProvidedType
+    _np = CTBase.Core.NotProvidedType
     _iter = Solutions.iterations(sol)
     _status = Solutions.status(sol)
     _msg = Solutions.message(sol)

--- a/test/suite/display/test_print.jl
+++ b/test/suite/display/test_print.jl
@@ -16,10 +16,12 @@ function test_print()
         # ====================================================================
 
         Test.@testset "AbstractDefinition display" begin
-            Test.@testset "show(EmptyDefinition) produces no output" begin
+            Test.@testset "show(EmptyDefinition) identifies empty definition" begin
                 io = IOBuffer()
                 show(io, MIME"text/plain"(), Components.EmptyDefinition())
-                Test.@test isempty(String(take!(io)))
+                s = String(take!(io))
+                Test.@test occursin("EmptyDefinition", s)
+                Test.@test occursin("empty", s)
             end
 
             Test.@testset "show(Definition) prints header" begin

--- a/test/suite/display/test_type_show.jl
+++ b/test/suite/display/test_type_show.jl
@@ -1,0 +1,97 @@
+module TestTypeShow
+
+using Test: Test
+using CTModels: Components, Building, Models, Serialization, Solutions, Init
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+function _show_string(value; plain=false, color=false)
+    io = IOBuffer()
+    context = IOContext(io, :color => color)
+    plain ? show(context, MIME"text/plain"(), value) : show(context, value)
+    return String(take!(io))
+end
+
+function test_type_show()
+    Test.@testset "Concrete type display" verbose=VERBOSE showtiming=SHOWTIMING begin
+        state = Components.StateModel("x", ["x₁", "x₂"])
+        state_solution = Components.StateModelSolution("x", ["x₁"], t -> 2t)
+        control = Components.ControlModel("u", ["u"])
+        control_solution = Components.ControlModelSolution("u", ["u"], t -> 0.0, :linear)
+        variable = Components.VariableModel("v", ["v"])
+        variable_solution = Components.VariableModelSolution("v", ["v"], 1.0)
+        fixed = Components.FixedTimeModel(0.0, "t₀")
+        free = Components.FreeTimeModel(2, "tf")
+        times = Components.TimesModel(fixed, free, "t")
+        objective = Components.BolzaObjectiveModel(
+            (x0, xf, v) -> 0.0, (t, x, u, v) -> 0.0, :min
+        )
+        constraints = Components.ConstraintsModel((), (), (), (), ())
+        grid = Solutions.UnifiedTimeGridModel([0.0, 1.0])
+        multi_grid = Solutions.MultipleTimeGridModel(
+            state=[0.0, 1.0], control=[0.0], costate=[0.0, 1.0], path=[0.0]
+        )
+        infos = Solutions.SolverInfos(
+            12, :first_order, "converged", true, 1e-8, Dict{Symbol,Any}()
+        )
+        dual = Solutions.DualModel(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)
+
+        for value in (
+            state,
+            state_solution,
+            control,
+            control_solution,
+            variable,
+            variable_solution,
+            fixed,
+            free,
+            times,
+            objective,
+            constraints,
+            grid,
+            multi_grid,
+            infos,
+            dual,
+            Components.EmptyControlModel(),
+            Components.EmptyVariableModel(),
+            Solutions.EmptyTimeGridModel(),
+            Solutions.EmptyDualModel(),
+            Components.EmptyDefinition(),
+            Serialization.JLD2Tag(),
+            Serialization.JSON3Tag(),
+        )
+            compact = _show_string(value)
+            detailed = _show_string(value; plain=true)
+            plain = _show_string(value; plain=true, color=false)
+            Test.@test !isempty(compact)
+            Test.@test !isempty(detailed)
+            Test.@test !occursin("\e[", plain)
+        end
+
+        Test.@test occursin("StateModel", _show_string(state; plain=true))
+        Test.@test occursin("dimension", _show_string(state; plain=true))
+        Test.@test occursin("interpolation", _show_string(control_solution; plain=true))
+        Test.@test occursin("criterion", _show_string(objective; plain=true))
+        Test.@test occursin("constraints violation", _show_string(infos; plain=true))
+        Test.@test occursin("state", _show_string(multi_grid; plain=true))
+        Test.@test occursin("status", _show_string(Solutions.EmptyDualModel(); plain=true))
+
+        subpath = Models.SubPathConstraint(((1,), (r, t, x, u, v) -> nothing), 1, 1)
+        projection = Models.BoxProjection{:state}(1)
+        merged = Init.MergedTrajectory(t -> [0.0], Dict{Int,Function}(), 1, :state)
+        constant = Components.ConstantInTime(1.0)
+        coerced = Components.CoercedTrajectory(t -> [1.0], only)
+        composite = Building.CompositeConstraint{:path}(1, [1], ((r, t, x, u, v) -> nothing,))
+        dual_slice = Solutions.DualSlice(t -> [1.0], 1)
+        dual_diff = Solutions.BoxDualDiff(t -> [1.0], t -> [0.0], 1)
+
+        for value in (subpath, projection, merged, constant, coerced, composite, dual_slice, dual_diff)
+            Test.@test !occursin("\e[", _show_string(value; plain=true, color=false))
+        end
+    end
+end
+
+end
+
+test_type_show() = TestTypeShow.test_type_show()


### PR DESCRIPTION
## Summary
- add CTBase palette-aware compact and detailed displays for concrete CTModels components and solution support types
- harmonize existing functor and serialization-tag displays with explicit `CTBase.Core` formatting
- document accessor-driven displays and add focused display regression tests

#### Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test(;test_args=["test/suite/display"])'`
- [x] Full test suite: 71,831 tests passed
- [x] `git diff --check`
- [x] Full Documenter build (not run because the current `docs/make.jl` would detect `docs/build/bases.txt` and may deploy VitePress)

Generated with [Devin](https://devin.ai)