### PR TITLE
Fix double-appended extension in export_ocp_solution/import_ocp_solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-08-23
+
+### 🐛 Bug Fixes
+
+- **`export_ocp_solution`/`import_ocp_solution` no longer double-append the format
+  extension** ([#399](https://github.com/control-toolbox/CTModels.jl/issues/399)).
+  `filename` is documented as a base name — the `.jld2`/`.json` extension is added
+  automatically — but a caller who already included it (`filename="sol.jld2"`) ended up
+  with `sol.jld2.jld2`. A new private helper, `Serialization._ensure_extension`, detects
+  the extension case-insensitively before appending, used by both extensions
+  (`CTModelsJLD`, `CTModelsJSON`) for both export and import.
+
+### ✅ Compatibility
+
+- **No breaking changes**: `filename` now additionally accepts names already ending in
+  the target extension; behavior for names that don't is unchanged. See
+  [BREAKING.md](BREAKING.md).
+
 ## [0.17.0] - 2026-08-16
 
 ### 🐛 Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/docs/src/serialization/export_import.md
+++ b/docs/src/serialization/export_import.md
@@ -71,6 +71,22 @@ nothing # hide
 x(0.5)
 ```
 
+## Extension appending is idempotent
+
+If `filename` already ends with the target extension (case-insensitively), it is left
+alone instead of being suffixed a second time:
+
+```@example exim
+base_json = base * ".json"
+CTModels.export_ocp_solution(sol; filename=base_json, format=:JSON)
+nothing # hide
+```
+
+```@repl exim
+isfile(base_json)
+isfile(base_json * ".json")
+```
+
 ## How trajectories survive serialization
 
 A trajectory is a *function* `t -> x(t)`, which neither JSON nor JLD2 can store directly.

--- a/ext/CTModelsJLD.jl
+++ b/ext/CTModelsJLD.jl
@@ -26,7 +26,8 @@ serialization warnings for function objects.
 - `sol::CTModels.Solution`: The optimal control solution to be saved.
 
 # Keyword Arguments
-- `filename::String = "solution"`: Base name of the file. The `.jld2` extension is automatically appended.
+- `filename::String = "solution"`: Base name of the file. The `.jld2` extension is
+  appended automatically, unless `filename` already ends with it (case-insensitively).
 
 # Example
 ```julia-repl
@@ -48,7 +49,7 @@ function CTModels.export_ocp_solution(
     data = CTModels.Solutions._serialize_solution(sol)
 
     # Save only the serialized data (no more OCP model)
-    JLD2.jldsave(filename * ".jld2"; solution_data=data)
+    JLD2.jldsave(CTModels.Serialization._ensure_extension(filename, ".jld2"); solution_data=data)
 
     return nothing
 end
@@ -66,7 +67,8 @@ reconstructs it using `build_solution` from the discretized data.
 - `ocp::CTModels.Model`: The associated optimal control problem model.
 
 # Keyword Arguments
-- `filename::String = "solution"`: Base name of the file. The `.jld2` extension is automatically appended.
+- `filename::String = "solution"`: Base name of the file. The `.jld2` extension is
+  appended automatically, unless `filename` already ends with it (case-insensitively).
 
 # Returns
 - `CTModels.Solution`: The reconstructed solution object.
@@ -87,7 +89,7 @@ function CTModels.import_ocp_solution(
     ::CTModels.JLD2Tag, ocp::CTModels.Model; filename::String
 )
     # Load the saved data
-    file_data = JLD2.load(filename * ".jld2")
+    file_data = JLD2.load(CTModels.Serialization._ensure_extension(filename, ".jld2"))
     data = file_data["solution_data"]
 
     infos = get(data, "infos", Dict{Symbol,Any}())

--- a/ext/CTModelsJSON.jl
+++ b/ext/CTModelsJSON.jl
@@ -181,7 +181,8 @@ including all primal and dual information, which can be read by external tools.
 - `sol::CTModels.Solution`: The solution to be saved.
 
 # Keyword Arguments
-- `filename::String = "solution"`: Base filename. The `.json` extension is automatically appended.
+- `filename::String = "solution"`: Base filename. The `.json` extension is appended
+  automatically, unless `filename` already ends with it (case-insensitively).
 
 # Notes
 The exported JSON includes the time grid, state, control, costate, objective, solver info, and all constraint duals (if available).
@@ -208,7 +209,7 @@ function CTModels.export_ocp_solution(
     blob["infos"] = infos_serialized
     blob["infos_symbol_keys"] = symbol_keys
 
-    open(filename * ".json", "w") do io
+    open(CTModels.Serialization._ensure_extension(filename, ".json"), "w") do io
         return JSON3.pretty(io, blob)
     end
 
@@ -260,7 +261,8 @@ including the discretized primal and dual trajectories.
 - `ocp::CTModels.Model`: The model associated with the optimal control problem. Used to rebuild the full solution.
 
 # Keyword Arguments
-- `filename::String = "solution"`: Base filename. The `.json` extension is automatically appended.
+- `filename::String = "solution"`: Base filename. The `.json` extension is appended
+  automatically, unless `filename` already ends with it (case-insensitively).
 
 # Returns
 - `CTModels.Solution`: A reconstructed solution instance.
@@ -278,7 +280,7 @@ julia> sol = CTModels.import_ocp_solution(CTModels.JSON3Tag(), model; filename="
 function CTModels.import_ocp_solution(
     ::CTModels.JSON3Tag, ocp::CTModels.Model; filename::String
 )
-    json_string = read(filename * ".json", String)
+    json_string = read(CTModels.Serialization._ensure_extension(filename, ".json"), String)
     blob = JSON3.read(json_string)
 
     # Restore Symbol types in infos (JSON3 deserializes all strings; metadata tracks which were Symbols)

--- a/src/Serialization/export_import.jl
+++ b/src/Serialization/export_import.jl
@@ -29,6 +29,34 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Return `filename` with `ext` appended, unless `filename` already ends with `ext`
+(case-insensitively).
+
+# Arguments
+- `filename::String`: base filename, with or without `ext`.
+- `ext::String`: extension to ensure, including the leading dot (e.g. `".json"`).
+
+# Returns
+- `String`: `filename` unchanged if it already ends with `ext`; `filename * ext` otherwise.
+
+# Example
+```julia-repl
+julia> using CTModels: Serialization
+
+julia> Serialization._ensure_extension("solution", ".json")
+"solution.json"
+
+julia> Serialization._ensure_extension("solution.json", ".json")
+"solution.json"
+```
+"""
+function _ensure_extension(filename::String, ext::String)::String
+    return endswith(lowercase(filename), lowercase(ext)) ? filename : filename * ext
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Export an optimal control solution to a file.
 
 # Arguments
@@ -36,7 +64,8 @@ Export an optimal control solution to a file.
 
 # Keyword Arguments
 - `format::Symbol=:JLD`: Export format, either `:JLD` or `:JSON`.
-- `filename::String="solution"`: Base filename (extension added automatically).
+- `filename::String="solution"`: Base filename; the extension is appended automatically,
+  unless `filename` already ends with it (case-insensitively).
 
 # Returns
 - `Nothing`: This function writes to a file and returns nothing.
@@ -78,7 +107,8 @@ Import an optimal control solution from a file.
 
 # Keyword Arguments
 - `format::Symbol=:JLD`: Import format, either `:JLD` or `:JSON`.
-- `filename::String="solution"`: Base filename (extension added automatically).
+- `filename::String="solution"`: Base filename; the extension is appended automatically,
+  unless `filename` already ends with it (case-insensitively).
 
 # Returns
 - `Solution`: The imported solution.

--- a/test/suite/serialization/test_export_import.jl
+++ b/test/suite/serialization/test_export_import.jl
@@ -1392,6 +1392,47 @@ function test_export_import()
 
             remove_if_exists("variable_dim1_dual_test.jld2")
         end
+
+        # ========================================================================
+        # Regression: filename already carrying the format extension
+        # https://github.com/control-toolbox/CTModels.jl/issues/399
+        # ========================================================================
+
+        Test.@testset "JSON round-trip: filename already ends with .json" begin
+            ocp, sol = TestProblems.solution_example()
+
+            Serialization.export_ocp_solution(
+                sol; filename="dup_ext_test.json", format=:JSON
+            )
+            Test.@test isfile("dup_ext_test.json")
+            Test.@test !isfile("dup_ext_test.json.json")
+
+            sol_reloaded = Serialization.import_ocp_solution(
+                ocp; filename="dup_ext_test.json", format=:JSON
+            )
+            Test.@test Solutions.objective(sol) ≈ Solutions.objective(sol_reloaded) atol =
+                1e-8
+
+            remove_if_exists("dup_ext_test.json")
+        end
+
+        Test.@testset "JLD round-trip: filename already ends with .jld2" begin
+            ocp, sol = TestProblems.solution_example()
+
+            Serialization.export_ocp_solution(
+                sol; filename="dup_ext_test.jld2", format=:JLD
+            )
+            Test.@test isfile("dup_ext_test.jld2")
+            Test.@test !isfile("dup_ext_test.jld2.jld2")
+
+            sol_reloaded = Serialization.import_ocp_solution(
+                ocp; filename="dup_ext_test.jld2", format=:JLD
+            )
+            Test.@test Solutions.objective(sol) ≈ Solutions.objective(sol_reloaded) atol =
+                1e-8
+
+            remove_if_exists("dup_ext_test.jld2")
+        end
     end
 end
 

--- a/test/suite/serialization/test_serialization_units.jl
+++ b/test/suite/serialization/test_serialization_units.jl
@@ -448,6 +448,33 @@ function test_serialization_units()
             Test.@test Components.variable(sol2) isa Float64
             Test.@test Components.variable(sol2) ≈ Components.variable(sol) atol = 1e-10
         end
+
+        # ==============================================================================
+        # C.8 — Regression: idempotent extension appending
+        #
+        # https://github.com/control-toolbox/CTModels.jl/issues/399
+        # `_ensure_extension` must append the format extension exactly once, whether or
+        # not the caller already included it (case-insensitively).
+        # ==============================================================================
+
+        Test.@testset "_ensure_extension: bare name gets extension appended" begin
+            Test.@test Serialization._ensure_extension("solution", ".json") == "solution.json"
+        end
+
+        Test.@testset "_ensure_extension: already suffixed, same case, is unchanged" begin
+            Test.@test Serialization._ensure_extension("solution.json", ".json") ==
+                "solution.json"
+        end
+
+        Test.@testset "_ensure_extension: already suffixed, different case, is unchanged" begin
+            Test.@test Serialization._ensure_extension("solution.JLD2", ".jld2") ==
+                "solution.JLD2"
+        end
+
+        Test.@testset "_ensure_extension: extension substring not at the end still appends" begin
+            Test.@test Serialization._ensure_extension("jld2_backup", ".jld2") ==
+                "jld2_backup.jld2"
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

- `filename` is documented as a base name for `export_ocp_solution`/`import_ocp_solution`, with the format's extension (`.jld2`/`.json`) appended automatically. If the caller already included the extension (`filename="sol.jld2"`), it got appended a second time (`sol.jld2.jld2`).
- Adds a private helper, `Serialization._ensure_extension`, that detects the extension case-insensitively before appending. Used by both extensions (`CTModelsJLD`, `CTModelsJSON`) at all 4 call sites (export/import, both formats).
- Updates the affected docstrings and the `export_import.md` guide to document and demonstrate the new idempotent behavior, and bumps the version to 0.17.1.

No breaking change — `filename` additionally accepts names already ending in the target extension; behavior for names that don't is unchanged.

Fixes #399

## Test plan

- [x] New unit tests for `_ensure_extension` (bare name, already-suffixed same case, already-suffixed different case, extension-like substring not at the end) — `test/suite/serialization/test_serialization_units.jl`
- [x] New integration regression tests: export/import round-trip with `filename` already carrying the extension, for both JSON and JLD2 — `test/suite/serialization/test_export_import.jl`
- [x] Full test suite: 73239/73239 passing
- [x] Doc build (`julia --project=. docs/make.jl`) clean; new `@example` cell in `export_import.md` executed and produces the claimed output (`isfile(base_json) == true`, `isfile(base_json * ".json") == false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)