### PR TITLE
Make times(sol) a simple alias for time_grid(sol); fix free-time bug

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,6 +4,35 @@
 
 This document describes breaking changes in CTModels releases and how to migrate your code.
 
+## [0.18.0] - 2026-08-23
+
+### `Components.times(sol)` returns the time grid instead of the times model
+
+`Components.times(sol::Solution)` used to return `sol.times`, the solution's
+`AbstractTimesModel` (fixed/free descriptors, names). It is now a simple alias for
+`Components.time_grid(sol)`: it returns the discretised time grid (same value/type as
+`time_grid(sol)`), and accepts the same optional `component` argument
+(`times(sol, :state)`, etc.) — see
+[#310](https://github.com/control-toolbox/CTModels.jl/issues/310).
+
+**Who is affected**: only code that calls `Components.times(sol)` (or
+`Models.times(sol)`/`Solutions.times(sol)`, the same re-exported generic) on a
+`Solution` and expects an `AbstractTimesModel` back. A search across the
+control-toolbox ecosystem (CTDirect.jl, CTFlows.jl, CTParser.jl, CTSolvers,
+OptimalControl.jl, CTBase) found no such call site as of this release — CTFlows.jl's
+`Integrators.times` is an unrelated generic on its own trajectory types, not this one.
+`Components.times` on a `Model` (as opposed to a `Solution`) is unaffected.
+
+**Migration**:
+
+- If you need the underlying `AbstractTimesModel` metadata (fixed/free, names), access
+  the `sol.times` field directly, or use the existing solution-level accessors
+  `Components.has_fixed_initial_time(sol)` / `has_free_initial_time(sol)` /
+  `has_fixed_final_time(sol)` / `has_free_final_time(sol)` /
+  `Components.initial_time_name(sol)` / `final_time_name(sol)`.
+- If you were already calling `Components.time_grid(sol)`, `times(sol)` now behaves
+  identically — no change needed.
+
 ## [0.17.0] - 2026-08-16
 
 ### `Solutions.variable_constraints_lb_dual`/`ub_dual` return a scalar for a 1-D variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-08-23
+
+### 💥 Changed
+
+- **`Components.times(sol)` is now a simple alias for `Components.time_grid(sol)`**
+  ([#310](https://github.com/control-toolbox/CTModels.jl/issues/310)). It previously
+  returned the solution's `AbstractTimesModel` metadata (fixed/free descriptors,
+  names) — for a free time, that struct only carries an index into the optimisation
+  variable, so the value was unusable without manually indexing `sol.variable`.
+  `times(sol)` now returns the discretised time grid, exactly like `time_grid(sol)`
+  (including the optional `component` argument, e.g. `times(sol, :state)`).
+
+### 🐛 Fixed
+
+- **`Components.initial_time(sol)` / `final_time(sol)` no longer throw
+  `MethodError` when the initial or final time is free**
+  ([#310](https://github.com/control-toolbox/CTModels.jl/issues/310)). They called
+  `initial_time(sol.times)` / `final_time(sol.times)` without passing `sol.variable`,
+  which only has a method for the fixed-time case. The dispatch matrix on
+  `TimesModel` is now complete (fixed/free × with/without a variable, vector or
+  scalar), and the solution-level accessors always pass `Components.variable(sol)`.
+
+See [BREAKING.md](BREAKING.md) for migration notes.
+
 ## [0.17.1] - 2026-08-23
 
 ### 🐛 Bug Fixes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTModels"
 uuid = "34c4fa32-2049-4079-8329-de33c2a22e2d"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/docs/src/solution/time_grids.md
+++ b/docs/src/solution/time_grids.md
@@ -82,6 +82,16 @@ length(CTModels.time_grid(sol_m, :control))
 length(CTModels.time_grid(sol_m, :costate))
 ```
 
+## `times` is an alias for `time_grid`
+
+[`times`](@ref CTModels.Components.times) on a solution is a simple alias for
+[`time_grid`](@ref CTModels.Components.time_grid): same arguments, same return value.
+
+```@repl grids
+CTModels.times(sol_u) == CTModels.time_grid(sol_u)
+CTModels.times(sol_m, :state) == CTModels.time_grid(sol_m, :state)
+```
+
 ## Component aliases
 
 `time_grid(sol, :states)`, `time_grid(sol, :duals)`, … accept many synonyms. They are

--- a/src/Components/times_accessors.jl
+++ b/src/Components/times_accessors.jl
@@ -207,6 +207,96 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Get the initial time from the times model, ignoring `variable` (fixed initial time).
+
+Completes the dispatch matrix so that `initial_time(model, variable)` works uniformly
+regardless of whether the initial time is fixed or free, and regardless of `variable`
+being a vector or a scalar (per the "1-D is a scalar" convention).
+
+# Arguments
+- `model::TimesModel{<:FixedTimeModel{T},<:AbstractTimeModel}`: The times model with fixed initial time.
+- `variable`: Ignored.
+
+# Returns
+- `T`: The fixed initial time value.
+
+See also: [`CTModels.Components.initial_time`](@extref), [`CTModels.Components.has_fixed_initial_time`](@extref).
+"""
+function initial_time(
+    model::TimesModel{<:FixedTimeModel{T},<:AbstractTimeModel}, ::Any
+)::T where {T<:Time}
+    return initial_time(model)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Get the final time from the times model, ignoring `variable` (fixed final time).
+
+Completes the dispatch matrix so that `final_time(model, variable)` works uniformly
+regardless of whether the final time is fixed or free, and regardless of `variable`
+being a vector or a scalar (per the "1-D is a scalar" convention).
+
+# Arguments
+- `model::TimesModel{<:AbstractTimeModel,<:FixedTimeModel{T}}`: The times model with fixed final time.
+- `variable`: Ignored.
+
+# Returns
+- `T`: The fixed final time value.
+
+See also: [`CTModels.Components.final_time`](@extref), [`CTModels.Components.has_fixed_final_time`](@extref).
+"""
+function final_time(
+    model::TimesModel{<:AbstractTimeModel,<:FixedTimeModel{T}}, ::Any
+)::T where {T<:Time}
+    return final_time(model)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Get the initial time from the times model, from a free initial time model and a scalar
+variable.
+
+# Arguments
+- `model::TimesModel{FreeTimeModel,<:AbstractTimeModel}`: The times model with free initial time.
+- `variable::T`: The scalar optimisation variable.
+
+# Returns
+- `T`: The initial time value from the variable.
+
+See also: [`CTModels.Components.final_time`](@extref), [`CTModels.Components.has_free_initial_time`](@extref).
+"""
+function initial_time(
+    model::TimesModel{FreeTimeModel,<:AbstractTimeModel}, variable::T
+)::T where {T<:ctNumber}
+    return initial_time(model, [variable])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Get the final time from the times model, from a free final time model and a scalar
+variable.
+
+# Arguments
+- `model::TimesModel{<:AbstractTimeModel,FreeTimeModel}`: The times model with free final time.
+- `variable::T`: The scalar optimisation variable.
+
+# Returns
+- `T`: The final time value from the variable.
+
+See also: [`CTModels.Components.initial_time`](@extref), [`CTModels.Components.has_free_final_time`](@extref).
+"""
+function final_time(
+    model::TimesModel{<:AbstractTimeModel,FreeTimeModel}, variable::T
+)::T where {T<:ctNumber}
+    return final_time(model, [variable])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Check if the initial time is fixed. Return true.
 
 # Returns

--- a/src/Solutions/build_solution.jl
+++ b/src/Solutions/build_solution.jl
@@ -1087,7 +1087,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Return the initial time of the solution.
+Return the initial time of the solution, whether fixed or free.
 
 # Arguments
 - `sol::Solution`: The optimal control solution.
@@ -1098,13 +1098,13 @@ Return the initial time of the solution.
 See also: [`CTModels.Components.final_time`](@extref), [`CTModels.Components.initial_time_name`](@extref).
 """
 function Components.initial_time(sol::Solution)::Real
-    return initial_time(sol.times)
+    return initial_time(sol.times, Components.variable(sol))
 end
 
 """
 $(TYPEDSIGNATURES)
 
-Return the final time of the solution.
+Return the final time of the solution, whether fixed or free.
 
 # Arguments
 - `sol::Solution`: The optimal control solution.
@@ -1115,7 +1115,7 @@ Return the final time of the solution.
 See also: [`CTModels.Components.initial_time`](@extref), [`CTModels.Components.final_time_name`](@extref).
 """
 function Components.final_time(sol::Solution)::Real
-    return final_time(sol.times)
+    return final_time(sol.times, Components.variable(sol))
 end
 
 """
@@ -1189,31 +1189,13 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Return the times model.
+Alias for [`CTModels.Components.time_grid`](@extref): return the solution's time grid
+(optionally for a given `component`).
 
-# Arguments
-- `sol::Solution`: The optimal control solution.
-
-# Returns
-- `TM`: The times model.
-
-See also: [`CTModels.Components.initial_time`](@extref), [`CTModels.Components.final_time`](@extref).
+See also: [`CTModels.Components.time_grid`](@extref).
 """
-function Components.times(
-    sol::Solution{
-        <:AbstractTimeGridModel,
-        TM,
-        <:AbstractStateModel,
-        <:AbstractControlModel,
-        <:AbstractVariableModel,
-        <:AbstractModel,
-        <:Function,
-        <:ctNumber,
-        <:AbstractDualModel,
-        <:AbstractSolverInfos,
-    },
-)::TM where {TM<:AbstractTimesModel}
-    return sol.times
+function Components.times(sol::Solution, args...)
+    return Components.time_grid(sol, args...)
 end
 
 """

--- a/test/suite/solutions/test_solution.jl
+++ b/test/suite/solutions/test_solution.jl
@@ -126,9 +126,9 @@ function test_solution()
             Test.@test Components.initial_time_name(sol) == "0.0"
             Test.@test Components.final_time_name(sol) == "1.0"
             Test.@test Solutions.time_grid(sol) == [0.0, 0.5, 1.0]
-            Test.@test Models.times(sol) isa Components.TimesModel
-            Test.@test Components.initial_time(Models.times(sol)) == 0
-            Test.@test Components.final_time(Models.times(sol)) == 1
+            # times(sol) is a simple alias for time_grid(sol)
+            Test.@test Models.times(sol) == Solutions.time_grid(sol)
+            Test.@test Models.times(sol) == [0.0, 0.5, 1.0]
             # Test direct time getters on solution
             Test.@test Components.initial_time(sol) == 0
             Test.@test Components.final_time(sol) == 1
@@ -136,6 +136,32 @@ function test_solution()
             Test.@test Components.has_free_initial_time(sol) == false
             Test.@test Components.has_fixed_final_time(sol) == true
             Test.@test Components.has_free_final_time(sol) == false
+        end
+        Test.@testset "time (free initial and final)" begin
+            pre_free = Building.PreModel()
+            Building.variable!(pre_free, 2, "z", ["a", "b"])
+            Building.time!(pre_free; ind0=1, indf=2, time_name=:s)
+            Building.state!(pre_free, 2, "y", ["u", "v"])
+            Building.control!(pre_free, 1, "w")
+            Building.dynamics!(pre_free, (r, t, x, u, v) -> r .= [x[1], u[1]])
+            Building.objective!(pre_free, :min; mayer=(x0, xf, v) -> x0[1] + xf[1])
+            Building.definition!(pre_free, quote end)
+            Building.time_dependence!(pre_free; autonomous=false)
+            ocp_free = Building.build(pre_free)
+
+            T_free = [0.0, 0.5, 1.0]
+            X_free = [0.0 0.0; 0.5 0.5; 1.0 1.0]
+            U_free = reshape([1.0, 2.0, 3.0], 3, 1)
+            v_free = [0.0, 1.0] # t0 = v[1] = 0.0, tf = v[2] = 1.0
+            P_free = zeros(3, 2)
+            sol_free = Solutions.build_solution(
+                ocp_free, T_free, X_free, U_free, v_free, P_free; kwargs...
+            )
+
+            Test.@test Components.has_free_initial_time(sol_free) == true
+            Test.@test Components.has_free_final_time(sol_free) == true
+            Test.@test Components.initial_time(sol_free) == v_free[1]
+            Test.@test Components.final_time(sol_free) == v_free[2]
         end
         Test.@testset "infos" begin
             Test.@test Models.objective(sol) == 0.5

--- a/test/suite/solutions/test_solution_multi_grids.jl
+++ b/test/suite/solutions/test_solution_multi_grids.jl
@@ -320,6 +320,11 @@ function test_solution_multi_grids()
                 # Test plural forms
                 Test.@test Solutions.time_grid(sol, :states) == T
                 Test.@test Solutions.time_grid(sol, :controls) == T
+
+                # times(sol) is a simple alias for time_grid(sol)
+                Test.@test Components.times(sol) == Solutions.time_grid(sol)
+                Test.@test Components.times(sol, :control) ==
+                    Solutions.time_grid(sol, :control)
             end
 
             Test.@testset "MultipleTimeGridModel getters" begin
@@ -365,6 +370,13 @@ function test_solution_multi_grids()
                 # Test plural forms
                 Test.@test Solutions.time_grid(sol, :states) == T_state
                 Test.@test Solutions.time_grid(sol, :controls) == T_control
+
+                # times(sol) is a simple alias for time_grid(sol)
+                Test.@test Components.times(sol) == Solutions.time_grid(sol)
+                Test.@test Components.times(sol, :state) ==
+                    Solutions.time_grid(sol, :state)
+                Test.@test Components.times(sol, :costate) ==
+                    Solutions.time_grid(sol, :costate)
 
                 # Test invalid component
                 Test.@test_throws Exceptions.IncorrectArgument Solutions.time_grid(


### PR DESCRIPTION
## Summary

- `Components.times(sol::Solution)` used to return `sol.times`, the solution's `AbstractTimesModel` metadata (fixed/free descriptors, names) — for a free time, that struct only carries an index into the optimisation variable, so the value was unusable without manually indexing `sol.variable`. `times(sol)` is now a simple alias for `Components.time_grid(sol)`: same value, same optional `component` argument.
- While investigating, found and fixed a related bug: `Components.initial_time(sol)` / `final_time(sol)` threw `MethodError` whenever the initial or final time was free, because they called `initial_time(sol.times)` / `final_time(sol.times)` without passing `sol.variable`. The `TimesModel` dispatch matrix is now complete (fixed/free × with/without a variable, vector or scalar), and the solution-level accessors always pass `Components.variable(sol)` through.
- Docs, `CHANGELOG.md`, and `BREAKING.md` updated; version bumped to `0.18.0` (breaking: `times(sol)`'s return type/value changes — no downstream package in the ecosystem was found calling it on a `Solution`).

Fixes #310

## Test plan

- [x] Targeted suites (`suite/solutions`, `suite/components`, `suite/building`) green after each phase
- [x] Full test suite green (73,276 assertions, 0 failures)
- [x] Docs built successfully in both draft and non-draft mode; the new `@repl` example blocks in `docs/src/solution/time_grids.md` were executed and confirmed to evaluate to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)